### PR TITLE
feat: implement RabbitMQ for durable room event handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,14 @@ pnpm dev
 | `PORT` | Yes | `apps/http-backend` | Set to `3001` to match frontend API config |
 | `DATABASE_URL` | Yes | `packages/db` and both backends | PostgreSQL connection string |
 | `REDIS_URL` | Yes for multi-node WS sync | `apps/ws-backend` | Redis connection string for room versioning and Pub/Sub |
+| `RABBITMQ_URL` | Yes for durable cross-node sync | `apps/ws-backend` | RabbitMQ connection string for durable room event queue |
+| `RABBITMQ_ROOM_EVENTS_EXCHANGE` | Optional | `apps/ws-backend` | RabbitMQ exchange name for room events, default `canvas.room.events` |
+| `RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX` | Optional | `apps/ws-backend` | Durable queue name prefix per node, default `canvas.room.events.node` |
+| `RABBITMQ_ROOM_EVENTS_PARTITIONS` | Optional | `apps/ws-backend` | Partition count for room routing keys, default `16` |
+| `RABBITMQ_PREFETCH` | Optional | `apps/ws-backend` | RabbitMQ consumer prefetch for backpressure, default `200` |
+| `RABBITMQ_DB_PERSIST_EXCHANGE` | Optional | `apps/ws-backend` | RabbitMQ exchange name for DB persist jobs, default `canvas.room.persist` |
+| `RABBITMQ_DB_PERSIST_QUEUE` | Optional | `apps/ws-backend` | Durable DB persist queue name, default `canvas.room.persist.jobs` |
+| `RABBITMQ_DB_PERSIST_ROUTING_KEY` | Optional | `apps/ws-backend` | Routing key for DB persist jobs, default `room.persist` |
 | `WS_MAX_MESSAGE_BYTES` | Optional | `apps/ws-backend` | Max accepted websocket payload bytes, default `524288` |
 | `WS_SNAPSHOT_RATE_LIMIT_COUNT` | Optional | `apps/ws-backend` | Max `canvas_snapshot` messages per window, default `30` |
 | `WS_SNAPSHOT_RATE_LIMIT_WINDOW_MS` | Optional | `apps/ws-backend` | Snapshot rate limit window in ms, default `1000` |
@@ -202,7 +210,7 @@ Snap controls connector endpoint binding for `line` and `arrow` shapes:
 - If auth/canvas requests fail, ensure HTTP backend is running on port `3001`.
 - If Prisma cannot connect, verify `DATABASE_URL` and check DB health with `pnpm db:logs`.
 - If multi-node realtime sync is not behaving as expected, verify `REDIS_URL` and Redis connectivity first.
-- RabbitMQ starts with `pnpm db:up`. Check broker health at `http://localhost:15672`.
+- If durable queue fan-out lags or stalls, verify `RABBITMQ_URL` and broker health at `http://localhost:15672`.
 - If either backend crashes on boot, confirm `JWT_SECRET` is set.
 - If code changes are not reflected in backend dev processes, rebuild/restart that app (current backend `dev` script compiles then starts).
 

--- a/apps/web/app/room/[userHandle]/[slug]/page.tsx
+++ b/apps/web/app/room/[userHandle]/[slug]/page.tsx
@@ -36,20 +36,21 @@ export default function RoomBySlugPage() {
 
                 const room = response.data?.data as ResolvedRoom;
                 const roomSlug = room?.slug;
-                const canonicalPath = room?.canonicalPath;
 
                 if (typeof roomSlug !== "string" || roomSlug.length === 0) {
                     throw new Error("Invalid room payload");
                 }
 
-                if (typeof canonicalPath === "string" && canonicalPath.length > 0) {
-                    window.location.replace(canonicalPath);
+                const destination = `/canvas/${encodeURIComponent(roomSlug)}?owner=${encodeURIComponent(userHandle)}`;
+                const currentLocation = `${window.location.pathname}${window.location.search}`;
+
+                // This route is a resolver shell only; always move to the canvas route.
+                // Guard against no-op replace calls that can trigger apparent refresh loops.
+                if (currentLocation === destination) {
                     return;
                 }
 
-                window.location.replace(
-                    `/canvas/${encodeURIComponent(roomSlug)}?owner=${encodeURIComponent(userHandle)}`
-                );
+                window.location.replace(destination);
             } catch (errorResponse) {
                 const axiosError = errorResponse as AxiosError<{message?: string}>;
                 if (axiosError.response?.status === 403) {

--- a/apps/ws-backend/package.json
+++ b/apps/ws-backend/package.json
@@ -21,6 +21,7 @@
     "@repo/canvas-engine": "workspace: *",
     "@repo/common": "workspace: *",
     "@repo/db": "workspace: *",
+    "@repo/queue-sync": "workspace: *",
     "@repo/redis-sync": "workspace: *",
     "@repo/typescript-config": "workspace:*",
     "@types/jsonwebtoken": "^9.0.10",

--- a/apps/ws-backend/src/index.ts
+++ b/apps/ws-backend/src/index.ts
@@ -1,7 +1,9 @@
 import "@repo/backend-common/config";
 import {WebSocketServer, WebSocket} from "ws";
+import {subscribeDurableRoomEvents, subscribeRoomPersistJobs} from "@repo/queue-sync";
 import {checkUser} from "./ws/auth.js";
 import {
+    activeRooms,
     broadcastRoomPresenceState,
     broadcastToRoomAll,
     leaveActiveRoom,
@@ -10,32 +12,81 @@ import {
     removeUserSocket,
 } from "./ws/connectionState.js";
 import {handleSocketMessage} from "./ws/messageHandler.js";
-import {cacheRoomSyncState} from "./ws/roomSync.js";
+import {cacheRoomSyncState, persistShapes, roomSyncState} from "./ws/roomSync.js";
 import {NODE_ID, subscribeRoomEvents} from "@repo/redis-sync";
 import type {AuthenticatedWebSocket} from "./ws/types.js";
 import type {ServerMessage} from "@repo/common";
+import type {RoomSnapshotBroadcastEvent} from "@repo/common/ws-protocol";
 import {
+    recordCrossNodeVersionRegression,
+    recordDuplicateCrossNodeEvent,
     recordConnectionClosed,
     recordConnectionOpened,
+    recordDurableEventConsumed,
     recordInboundMessage,
     recordRedisFanoutEvent,
     startMetricsReporter,
 } from "./ws/metrics.js";
 
 const wss = new WebSocketServer({port: 8080});
+const RABBITMQ_RETRY_DELAY_MS = 2000;
 
 console.log("WebSocket server online on port 8080");
 startMetricsReporter();
 
-// Redis Pub/Sub is the cross-node distribution layer. Each WS process still
-// owns its local sockets, but all processes observe the same room events.
-void subscribeRoomEvents(async (event) => {
+const seenActionIds = new Map<string, number>();
+const ACTION_ID_TTL_MS = 2 * 60 * 1000;
+
+function rememberAction(actionId: string) {
+    seenActionIds.set(actionId, Date.now());
+}
+
+function hasSeenAction(actionId: string) {
+    const seenAt = seenActionIds.get(actionId);
+    if (!seenAt) {
+        return false;
+    }
+
+    if (Date.now() - seenAt > ACTION_ID_TTL_MS) {
+        seenActionIds.delete(actionId);
+        return false;
+    }
+
+    return true;
+}
+
+setInterval(() => {
+    const now = Date.now();
+    for (const [actionId, seenAt] of seenActionIds) {
+        if (now - seenAt > ACTION_ID_TTL_MS) {
+            seenActionIds.delete(actionId);
+        }
+    }
+}, ACTION_ID_TTL_MS).unref();
+
+async function applyCrossNodeRoomEvent(event: RoomSnapshotBroadcastEvent, source: "redis" | "rabbitmq") {
     if (event.originNodeId === NODE_ID) {
-        // The originating node already handled the local socket update.
         return;
     }
 
-    recordRedisFanoutEvent(Math.max(0, Date.now() - event.publishedAtMs));
+    if (hasSeenAction(event.actionId)) {
+        recordDuplicateCrossNodeEvent();
+        return;
+    }
+
+    rememberAction(event.actionId);
+
+    const cachedState = roomSyncState.get(event.roomId);
+    if (cachedState && event.version <= cachedState.version) {
+        recordCrossNodeVersionRegression();
+        return;
+    }
+
+    if (cachedState && event.version > cachedState.version + 1) {
+        // We can still apply because events carry full snapshots, but this
+        // indicates transport lag or a missed intermediate version.
+        recordCrossNodeVersionRegression();
+    }
 
     cacheRoomSyncState({
         roomId: event.roomId,
@@ -43,17 +94,76 @@ void subscribeRoomEvents(async (event) => {
         shapes: event.shapes,
     });
 
+    if (source === "rabbitmq") {
+        recordDurableEventConsumed();
+    } else {
+        recordRedisFanoutEvent(Math.max(0, Date.now() - event.publishedAtMs));
+    }
+
+    const localRoomSockets = activeRooms.get(event.roomId);
+    if (!localRoomSockets || localRoomSockets.size === 0) {
+        return;
+    }
+
     const message: ServerMessage = {
         type: event.type,
         roomId: event.roomId,
         version: event.version,
         shapes: event.shapes,
         senderId: event.senderId ?? "unknown",
+        actionId: event.actionId,
     };
 
-    // Forward the Redis event to the local clients currently joined to this room.
     broadcastToRoomAll(event.roomId, message);
+}
+
+// Cross-node room events use a hybrid transport:
+// - RabbitMQ durable queue for replay and reliability.
+// - Redis Pub/Sub fallback for low-latency best-effort fan-out.
+void subscribeRoomEvents(async (event) => {
+    await applyCrossNodeRoomEvent(event, "redis");
 });
+
+function startDurableRoomEventConsumer() {
+    void subscribeDurableRoomEvents(NODE_ID, async (event) => {
+        await applyCrossNodeRoomEvent(event, "rabbitmq");
+    }).catch((error) => {
+        console.error("[WS] Durable room event consumer unavailable; retrying", {
+            delayMs: RABBITMQ_RETRY_DELAY_MS,
+            error,
+        });
+
+        setTimeout(() => {
+            startDurableRoomEventConsumer();
+        }, RABBITMQ_RETRY_DELAY_MS).unref();
+    });
+}
+
+const latestPersistedVersionByRoom = new Map<number, number>();
+
+function startRoomPersistConsumer() {
+    void subscribeRoomPersistJobs(async (job) => {
+        const knownPersistedVersion = latestPersistedVersionByRoom.get(job.roomId) ?? 0;
+        if (job.version <= knownPersistedVersion) {
+            return;
+        }
+
+        await persistShapes(job.roomId, job.shapes);
+        latestPersistedVersionByRoom.set(job.roomId, job.version);
+    }).catch((error) => {
+        console.error("[WS] Durable DB persist consumer unavailable; retrying", {
+            delayMs: RABBITMQ_RETRY_DELAY_MS,
+            error,
+        });
+
+        setTimeout(() => {
+            startRoomPersistConsumer();
+        }, RABBITMQ_RETRY_DELAY_MS).unref();
+    });
+}
+
+startDurableRoomEventConsumer();
+startRoomPersistConsumer();
 
 wss.on("connection", function connection(ws: AuthenticatedWebSocket, request) {
     const authUser = checkUser(request);

--- a/apps/ws-backend/src/ws/messageHandler.ts
+++ b/apps/ws-backend/src/ws/messageHandler.ts
@@ -1,9 +1,11 @@
+import {randomUUID} from "node:crypto";
 import {RawData} from "ws";
 import type {Shape} from "@repo/canvas-engine";
 import {ClientWsMessageSchema} from "@repo/common/ws-protocol";
 import type {ServerMessage} from "@repo/common";
 import {prismaClient} from "@repo/db/client";
 import type {AuthenticatedWebSocket} from "./types.js";
+import {publishDurableRoomEvent} from "@repo/queue-sync";
 import {
     broadcastRoomPresenceState,
     broadcastToRoom,
@@ -11,7 +13,7 @@ import {
     joinActiveRoom,
     setRoomPresence,
 } from "./connectionState.js";
-import {cacheRoomSyncState, initializeRoomSync, scheduleRoomPersist} from "./roomSync.js";
+import {cacheRoomSyncState, enqueueRoomPersist, initializeRoomSync} from "./roomSync.js";
 import {commitRoomSnapshot, getRoomVersion, NODE_ID} from "@repo/redis-sync";
 import {
     recordInvalidJsonPayload,
@@ -21,6 +23,7 @@ import {
     recordSnapshotCommitFailure,
     recordSnapshotCommitted,
     recordVersionMismatch,
+    recordDurablePublishFailure,
 } from "./metrics.js";
 
 const WS_MAX_MESSAGE_BYTES = Number(process.env.WS_MAX_MESSAGE_BYTES ?? 512 * 1024);
@@ -229,6 +232,7 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
     if (parsed.type === "canvas_snapshot") {
         const {roomId, version, shapes} = parsed;
         const snapshotStartedAtMs = Date.now();
+        const actionId = randomUUID();
 
         if (isSnapshotRateLimited(ws)) {
             recordRateLimitedSnapshot();
@@ -325,6 +329,7 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
         const nextVersion = await commitRoomSnapshot(roomId, version, typedShapes, {
             originNodeId: NODE_ID,
             senderId: userId,
+            actionId,
         });
 
         if (!nextVersion) {
@@ -357,7 +362,29 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
         const processLatencyMs = Math.max(0, Date.now() - snapshotStartedAtMs);
         recordSnapshotCommitted(commitLatencyMs, processLatencyMs);
 
-        scheduleRoomPersist(roomId, typedShapes);
+        try {
+            await publishDurableRoomEvent({
+                type: "canvas_snapshot_broadcast",
+                roomId,
+                version: nextVersion,
+                shapes: typedShapes,
+                senderId: userId,
+                originNodeId: NODE_ID,
+                actionId,
+                publishedAtMs: Date.now(),
+            });
+        } catch (error) {
+            // Redis Pub/Sub remains available as low-latency fan-out fallback.
+            recordDurablePublishFailure();
+            console.error("[WS] Failed to publish durable room event", {
+                roomId,
+                version: nextVersion,
+                actionId,
+                error,
+            });
+        }
+
+        await enqueueRoomPersist(roomId, nextVersion, typedShapes);
         cacheRoomSyncState({
             roomId,
             version: nextVersion,
@@ -380,6 +407,7 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
             version: nextVersion,
             shapes: typedShapes,
             senderId: userId,
+            actionId,
         };
 
         broadcastToRoom(roomId, broadcastMsg, ws);

--- a/apps/ws-backend/src/ws/metrics.ts
+++ b/apps/ws-backend/src/ws/metrics.ts
@@ -22,7 +22,11 @@ type CounterKey =
     | "redisFanoutLagLe10ms"
     | "redisFanoutLagLe50ms"
     | "redisFanoutLagLe100ms"
-    | "redisFanoutLagGt100ms";
+    | "redisFanoutLagGt100ms"
+    | "durableEventsConsumed"
+    | "durablePublishFailures"
+    | "duplicateCrossNodeEvents"
+    | "crossNodeVersionRegressions";
 
 type Counters = Record<CounterKey, number>;
 
@@ -51,6 +55,10 @@ const totals: Counters = {
     redisFanoutLagLe50ms: 0,
     redisFanoutLagLe100ms: 0,
     redisFanoutLagGt100ms: 0,
+    durableEventsConsumed: 0,
+    durablePublishFailures: 0,
+    duplicateCrossNodeEvents: 0,
+    crossNodeVersionRegressions: 0,
 };
 
 let windowCounters: Counters = {...totals};
@@ -150,6 +158,22 @@ export function recordRedisFanoutEvent(fanoutLagMs?: number) {
     }
 }
 
+export function recordDurableEventConsumed() {
+    inc("durableEventsConsumed");
+}
+
+export function recordDurablePublishFailure() {
+    inc("durablePublishFailures");
+}
+
+export function recordDuplicateCrossNodeEvent() {
+    inc("duplicateCrossNodeEvents");
+}
+
+export function recordCrossNodeVersionRegression() {
+    inc("crossNodeVersionRegressions");
+}
+
 export function startMetricsReporter(intervalMs = Number(process.env.WS_METRICS_LOG_INTERVAL_MS ?? 30000)) {
     if (reportStarted || !Number.isFinite(intervalMs) || intervalMs <= 0) {
         return;
@@ -184,6 +208,10 @@ export function startMetricsReporter(intervalMs = Number(process.env.WS_METRICS_
             redisFanoutLagLe50ms: 0,
             redisFanoutLagLe100ms: 0,
             redisFanoutLagGt100ms: 0,
+            durableEventsConsumed: 0,
+            durablePublishFailures: 0,
+            duplicateCrossNodeEvents: 0,
+            crossNodeVersionRegressions: 0,
         };
 
         console.info("[WS][metrics]", {

--- a/apps/ws-backend/src/ws/roomSync.ts
+++ b/apps/ws-backend/src/ws/roomSync.ts
@@ -1,6 +1,8 @@
+import {randomUUID} from "node:crypto";
 import {prismaClient} from "@repo/db/client";
 import type {Shape} from "@repo/canvas-engine";
 import type {RoomSyncState} from "@repo/common";
+import {publishRoomPersistJob} from "@repo/queue-sync";
 import {getRoomSnapshot, getRoomVersion, setRoomSnapshot} from "@repo/redis-sync";
 
 /**
@@ -139,4 +141,23 @@ export function scheduleRoomPersist(roomId: number, shapes: Shape[], delayMs = 1
     }, delayMs);
 
     pendingPersistTimer.set(roomId, timer);
+}
+
+/**
+ * Persist through RabbitMQ so DB writes are durable and replayable.
+ * Falls back to in-process debounce persistence if the queue is unavailable.
+ */
+export async function enqueueRoomPersist(roomId: number, version: number, shapes: Shape[]) {
+    try {
+        await publishRoomPersistJob({
+            jobId: randomUUID(),
+            roomId,
+            version,
+            shapes,
+            enqueuedAtMs: Date.now(),
+        });
+    } catch (error) {
+        console.error(`[WS] Failed to enqueue room ${roomId} persist job; using local fallback`, error);
+        scheduleRoomPersist(roomId, shapes);
+    }
 }

--- a/docs/scaling-runbook.md
+++ b/docs/scaling-runbook.md
@@ -10,6 +10,7 @@ Use these as initial targets for realtime collaboration:
 - Redis fan-out lag (published -> received on peer node): p95 <= 50ms
 - Version mismatch rate: < 1% of `canvas_snapshot` messages
 - Snapshot commit failure rate: < 0.5%
+- Durable publish failure rate: < 0.1%
 
 These targets should be adjusted after the first realistic load test cycle.
 
@@ -25,6 +26,8 @@ Track at minimum:
 - consistency signals: `versionMismatches`
 - write path health: `snapshotsCommitted`, `snapshotCommitFailures`
 - latency buckets: `snapshotCommitLatency*`, `snapshotProcessLatency*`, `redisFanoutLag*`
+- durable transport health: `durableEventsConsumed`, `durablePublishFailures`
+- idempotency and ordering: `duplicateCrossNodeEvents`, `crossNodeVersionRegressions`
 
 ## 3. Alert Conditions
 
@@ -34,10 +37,12 @@ Start with simple rule-based alerts:
 - `snapshotCommitFailures > 0` for 3 consecutive windows
 - `rateLimitedSnapshots > 0` sustained for 10 min
 - `redisFanoutLagGt100ms > 0` sustained for 5 min
+- `durablePublishFailures > 0` for 3 consecutive windows
+- `crossNodeVersionRegressions > 0` sustained for 5 min
 
 ## 4. Load Test Procedure
 
-1. Deploy at least 2 WS nodes with Redis.
+1. Deploy at least 2 WS nodes with Redis and RabbitMQ.
 2. Run simulated rooms at 10, 25, and 50 users per room.
 3. For each scenario, run at least 10 minutes with burst editing.
 4. Collect metrics windows and compute p50/p95/p99 for latency buckets.
@@ -56,12 +61,16 @@ WS backend knobs exposed via env vars:
 - `WS_SNAPSHOT_RATE_LIMIT_COUNT`
 - `WS_SNAPSHOT_RATE_LIMIT_WINDOW_MS`
 - `WS_METRICS_LOG_INTERVAL_MS`
+- `RABBITMQ_ROOM_EVENTS_PARTITIONS`
+- `RABBITMQ_PREFETCH`
 
 Tuning guidance:
 
 - If `oversizedMessages` spikes: lower client payload size expectations and/or adjust serialization strategy.
 - If `rateLimitedSnapshots` spikes: increase limit only after confirming traffic is legitimate.
 - If fan-out lag spikes with stable Redis health: reduce snapshot payload size or move toward delta updates.
+- If durable consumer lag rises: tune `RABBITMQ_PREFETCH` and verify broker resources.
+- If durable publish failures rise: verify broker connectivity and queue durability settings first.
 
 ## 6. Next Optimization Trigger
 

--- a/docs/ws-redis-sync-architecture.md
+++ b/docs/ws-redis-sync-architecture.md
@@ -1,17 +1,19 @@
-# WebSocket Redis Sync Architecture
+# WebSocket Realtime Sync Architecture
 
-This document describes the Redis-backed synchronization path for the WebSocket backend.
+This document describes the Redis + RabbitMQ synchronization path for the WebSocket backend.
 
 ## Goals
 
 - Keep Redis as the authoritative source of truth for room version and latest snapshot.
-- Allow multiple WebSocket servers to broadcast room updates consistently.
+- Use RabbitMQ as the durable room-event queue for cross-node replay and reliability.
+- Keep Redis Pub/Sub as low-latency fan-out fallback during queue transport incidents.
 - Keep the browser protocol unchanged.
 - Treat in-memory room state as a cache, not as authority.
 
 ## Package Ownership
 
 Redis room sync primitives now live in the shared package `@repo/redis-sync`.
+RabbitMQ room queue primitives now live in the shared package `@repo/queue-sync`.
 
 Why this package exists:
 
@@ -35,16 +37,24 @@ The room snapshot lifecycle is:
 1. A client sends `canvas_snapshot` to the WebSocket server.
 2. The server validates the request and checks the authoritative room version in Redis.
 3. If the client version matches, the server atomically increments the Redis version and stores the new snapshot.
-4. The server publishes a room event to Redis Pub/Sub with the new snapshot and version.
-5. All WebSocket nodes receive the event and forward it to their local room clients.
-6. If the client version does not match, the server sends `sync_error` and the latest authoritative snapshot so the client can resync.
+4. The server publishes a durable room event to RabbitMQ and a low-latency fallback event to Redis Pub/Sub.
+5. All WebSocket nodes consume room events, deduplicate by `actionId`, and apply monotonic version checks.
+6. Nodes forward validated events to local room clients.
+7. If the client version does not match, the server sends `sync_error` and the latest authoritative snapshot so the client can resync.
 
-## Why Redis
+## Why Redis + RabbitMQ
 
-Redis is used here for two different reasons:
+Redis is used here for two reasons:
 
 - Versioning: a single Redis key per room holds the latest authoritative version.
-- Fan-out: Pub/Sub distributes cross-node room updates with low latency.
+- Fast fallback fan-out: Pub/Sub distributes cross-node room updates with low latency.
+
+RabbitMQ is used for durable room-event delivery:
+
+- Durable queueing: events survive node restarts/disconnects.
+- Room-level partition routing: routing key is derived from `roomId` partition.
+- Backpressure: consumer prefetch controls in-flight event load.
+- Replay to nodes: durable per-node queue allows catch-up after node reconnect.
 
 That split gives us the minimum infrastructure needed to support multiple WebSocket servers without changing the frontend protocol.
 
@@ -54,9 +64,16 @@ That split gives us the minimum infrastructure needed to support multiple WebSoc
 
 - `canvas:room:version:<roomId>`: authoritative version number.
 - `canvas:room:snapshot:<roomId>`: latest serialized room snapshot.
-- `canvas:room:<roomId>` channel: cross-node room updates.
+- `canvas:room:<roomId>` channel: low-latency fallback cross-node updates.
 
-Redis room events also include `publishedAtMs` so WS nodes can measure cross-node fan-out lag.
+Redis room events include `publishedAtMs` and `actionId` so WS nodes can measure fan-out lag and deduplicate with durable queue events.
+
+### RabbitMQ
+
+- Exchange (default): `canvas.room.events`.
+- Routing keys: `room.partition.<n>` where `n = roomId % partitions`.
+- Per-node durable queue: `canvas.room.events.node.<nodeId>`.
+- Payload: canonical `canvas_snapshot_broadcast` room event with `actionId`.
 
 ### In memory
 
@@ -71,7 +88,9 @@ Redis room events also include `publishedAtMs` so WS nodes can measure cross-nod
 ## Important Design Rules
 
 - Redis is authoritative for version checks.
-- Redis events must include `originNodeId` so a node can ignore its own published updates.
+- Cross-node events must include `originNodeId` so a node can ignore its own published updates.
+- Cross-node events must include `actionId` and pass schema validation before fan-out.
+- Nodes apply monotonic room-version checks to avoid stale event regressions.
 - The WebSocket protocol stays unchanged for the browser.
 - Local in-memory room state may be stale and should only be treated as a cache.
 
@@ -83,19 +102,21 @@ What already enables it:
 
 - Redis-hosted authoritative room version.
 - Redis-hosted room snapshot fallback.
-- Pub/Sub fan-out for cross-node room updates.
+- Durable RabbitMQ room-event queue for replay and resiliency.
+- Pub/Sub fallback fan-out for fast-path updates.
 - `originNodeId` filtering to avoid duplicate local rebroadcast loops.
+- `actionId` dedupe across RabbitMQ + Pub/Sub to keep fan-out idempotent.
 
 Current scaling limits:
 
 - Full snapshot payloads are still expensive at high edit rates.
-- Pub/Sub has no replay semantics; reconnect paths rely on snapshot recovery.
+- Per-room events are still full snapshots, so payload size dominates at high edit rates.
 - Persistence strategy is still full-room replace, which can bottleneck under heavy load.
 
 ## Failure Behavior
 
 - If Redis is temporarily unavailable, room sync cannot safely accept new writes because version authority is missing.
-- If a node misses a Pub/Sub event while disconnected, the next client mismatch or join will recover the room from Redis or Postgres.
+- If a node misses fallback Pub/Sub events, RabbitMQ durable queue replay catches up on reconnect.
 - If Redis has a version but no snapshot, the backend rebuilds the snapshot from Postgres and reattaches it to the Redis version.
 
 ## Why This Is Better Than Memory-Only Sync
@@ -119,21 +140,30 @@ Current status:
 - Implemented payload-size guardrail and snapshot rate limiting.
 - Implemented latency bucket telemetry for snapshot commit, snapshot process path, and Redis fan-out lag.
 
+### Phase 2B: Durable Queue and Ordering
+
+Current status:
+
+- Implemented RabbitMQ durable room-event publication.
+- Implemented per-node durable queue consumption with prefetch backpressure control.
+- Implemented room-event idempotency using `actionId` dedupe.
+- Implemented monotonic version guards for cross-node event application.
+
 See [docs/scaling-runbook.md](docs/scaling-runbook.md) for SLO targets, alert rules, and load-test procedure.
 
-### Phase 2B: Load and Capacity Testing
+### Phase 2C: Load and Capacity Testing
 
 - Run multi-node WS load tests with realistic room sizes.
 - Define room-level and cluster-level SLO thresholds.
 - Capture payload byte distributions to identify hot rooms.
 
-### Phase 2C: Protocol Efficiency
+### Phase 2D: Protocol Efficiency
 
 - Move from full snapshots to operation/delta events.
 - Keep periodic checkpoints for reconnect recovery.
 - Reduce fan-out payload cost and DB write amplification.
 
-### Phase 2D: Durable Asynchronous Pipeline
+### Phase 2E: Durable Asynchronous Pipeline
 
 - Add queue/stream-backed workers for persistence and analytics workloads.
 - Keep Redis Pub/Sub for live fan-out; use queue/stream for durability and retries.

--- a/packages/backend-common/src/config.ts
+++ b/packages/backend-common/src/config.ts
@@ -21,6 +21,14 @@ for (const envPath of envCandidates) {
 
 const jwtSecret = process.env.JWT_SECRET;
 const redisUrl = process.env.REDIS_URL ?? "redis://127.0.0.1:6379";
+const rabbitmqUrl = process.env.RABBITMQ_URL ?? "amqp://guest:guest@127.0.0.1:5672";
+const rabbitmqRoomEventsExchange = process.env.RABBITMQ_ROOM_EVENTS_EXCHANGE ?? "canvas.room.events";
+const rabbitmqRoomEventsQueuePrefix = process.env.RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX ?? "canvas.room.events.node";
+const rabbitmqRoomEventsPartitions = Number(process.env.RABBITMQ_ROOM_EVENTS_PARTITIONS ?? 16);
+const rabbitmqPrefetch = Number(process.env.RABBITMQ_PREFETCH ?? 200);
+const rabbitmqDbPersistExchange = process.env.RABBITMQ_DB_PERSIST_EXCHANGE ?? "canvas.room.persist";
+const rabbitmqDbPersistQueue = process.env.RABBITMQ_DB_PERSIST_QUEUE ?? "canvas.room.persist.jobs";
+const rabbitmqDbPersistRoutingKey = process.env.RABBITMQ_DB_PERSIST_ROUTING_KEY ?? "room.persist";
 
 if (!jwtSecret) {
     throw new Error("JWT_SECRET is not defined");
@@ -28,3 +36,11 @@ if (!jwtSecret) {
 
 export const JWT_SECRET: string = jwtSecret;
 export const REDIS_URL: string = redisUrl;
+export const RABBITMQ_URL: string = rabbitmqUrl;
+export const RABBITMQ_ROOM_EVENTS_EXCHANGE: string = rabbitmqRoomEventsExchange;
+export const RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX: string = rabbitmqRoomEventsQueuePrefix;
+export const RABBITMQ_ROOM_EVENTS_PARTITIONS: number = rabbitmqRoomEventsPartitions;
+export const RABBITMQ_PREFETCH: number = rabbitmqPrefetch;
+export const RABBITMQ_DB_PERSIST_EXCHANGE: string = rabbitmqDbPersistExchange;
+export const RABBITMQ_DB_PERSIST_QUEUE: string = rabbitmqDbPersistQueue;
+export const RABBITMQ_DB_PERSIST_ROUTING_KEY: string = rabbitmqDbPersistRoutingKey;

--- a/packages/common/src/ws-protocol.ts
+++ b/packages/common/src/ws-protocol.ts
@@ -15,6 +15,8 @@ const CanvasShapeSchema = z
   })
   .passthrough();
 
+const ActionIdSchema = z.string().min(8).max(128);
+
 /**
  * Cursor position shared between collaborators for presence rendering.
  */
@@ -73,6 +75,7 @@ export type WsMessage =
       version: number;
       shapes: Shape[];
       senderId: string;
+      actionId?: string;
     }
   | {
       type: "canvas_snapshot_ack";
@@ -107,6 +110,7 @@ export type ServerMessage =
       version: number;
       shapes: Shape[];
       senderId: string;
+      actionId?: string;
     }
   | {
       type: "canvas_snapshot_ack";
@@ -165,3 +169,29 @@ export interface RoomSyncState {
   version: number;
   shapes: Shape[];
 }
+
+/**
+ * Canonical server-to-server snapshot event used by Redis Pub/Sub and
+ * durable queue transport.
+ */
+export type RoomSnapshotBroadcastEvent = {
+  type: "canvas_snapshot_broadcast";
+  roomId: number;
+  version: number;
+  shapes: Shape[];
+  senderId?: string;
+  originNodeId: string;
+  actionId: string;
+  publishedAtMs: number;
+};
+
+export const RoomSnapshotBroadcastEventSchema = z.object({
+  type: z.literal("canvas_snapshot_broadcast"),
+  roomId: z.number().int().positive(),
+  version: z.number().int().min(1),
+  shapes: z.array(CanvasShapeSchema).max(5000),
+  senderId: z.string().min(1).max(200).optional(),
+  originNodeId: z.string().min(1).max(200),
+  actionId: ActionIdSchema,
+  publishedAtMs: z.number().int().nonnegative(),
+});

--- a/packages/queue-sync/package.json
+++ b/packages/queue-sync/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@repo/queue-sync",
+  "version": "1.0.0",
+  "description": "RabbitMQ durable room event primitives for cross-node sync",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@repo/backend-common": "workspace: *",
+    "@repo/canvas-engine": "workspace: *",
+    "@repo/common": "workspace: *",
+    "amqplib": "^0.10.8",
+    "zod": "^4.1.11"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace: *",
+    "@types/amqplib": "^0.10.7",
+    "@types/node": "^22.15.3"
+  }
+}

--- a/packages/queue-sync/src/index.ts
+++ b/packages/queue-sync/src/index.ts
@@ -1,0 +1,458 @@
+import amqp, {type Channel, type ChannelModel, type ConfirmChannel, type ConsumeMessage, type Options} from "amqplib";
+import {once} from "node:events";
+import type {Shape} from "@repo/canvas-engine";
+import {
+    RABBITMQ_DB_PERSIST_EXCHANGE,
+    RABBITMQ_DB_PERSIST_QUEUE,
+    RABBITMQ_DB_PERSIST_ROUTING_KEY,
+    RABBITMQ_PREFETCH,
+    RABBITMQ_ROOM_EVENTS_EXCHANGE,
+    RABBITMQ_ROOM_EVENTS_PARTITIONS,
+    RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX,
+    RABBITMQ_URL,
+} from "@repo/backend-common/config";
+import {
+    RoomSnapshotBroadcastEventSchema,
+    type RoomSnapshotBroadcastEvent,
+} from "@repo/common/ws-protocol";
+import {z} from "zod";
+
+const DbPersistShapeSchema = z
+    .object({
+        id: z.string().min(1).max(200),
+        type: z.string().min(1).max(64),
+    })
+    .passthrough();
+
+const RoomPersistJobSchema = z.object({
+    jobId: z.string().min(8).max(128),
+    roomId: z.number().int().positive(),
+    version: z.number().int().min(1),
+    shapes: z.array(DbPersistShapeSchema).max(5000),
+    enqueuedAtMs: z.number().int().nonnegative(),
+});
+
+export type RoomPersistJob = {
+    jobId: string;
+    roomId: number;
+    version: number;
+    shapes: Shape[];
+    enqueuedAtMs: number;
+};
+
+let publisherConnection: ChannelModel | null = null;
+let publisherChannel: ConfirmChannel | null = null;
+let subscriberConnection: ChannelModel | null = null;
+let subscriberChannel: Channel | null = null;
+let persistSubscriberConnection: ChannelModel | null = null;
+let persistSubscriberChannel: Channel | null = null;
+let activeConsumerTag: string | null = null;
+let activePersistConsumerTag: string | null = null;
+let subscribedNodeId: string | null = null;
+let subscribedHandler: ((event: RoomSnapshotBroadcastEvent) => void | Promise<void>) | null = null;
+let persistSubscribedHandler: ((job: RoomPersistJob) => void | Promise<void>) | null = null;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let persistReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+function normalizePositiveInt(value: number, fallback: number) {
+    if (!Number.isFinite(value) || value <= 0) {
+        return fallback;
+    }
+
+    return Math.floor(value);
+}
+
+function roomPartition(roomId: number) {
+    const partitions = normalizePositiveInt(RABBITMQ_ROOM_EVENTS_PARTITIONS, 16);
+    return roomId % partitions;
+}
+
+function partitionRoutingKey(partition: number) {
+    return `room.partition.${partition}`;
+}
+
+async function assertExchange(channel: Channel) {
+    await channel.assertExchange(RABBITMQ_ROOM_EVENTS_EXCHANGE, "direct", {
+        durable: true,
+    });
+}
+
+async function createPublisherChannel() {
+    publisherConnection = await amqp.connect(RABBITMQ_URL);
+    const connection = publisherConnection;
+
+    connection.on("error", (error) => {
+        console.error("[WS][RabbitMQ] publisher connection error", error);
+    });
+    connection.on("close", () => {
+        publisherConnection = null;
+        publisherChannel = null;
+    });
+
+    const channel = await connection.createConfirmChannel();
+    publisherChannel = channel;
+    await assertExchange(channel);
+    await channel.assertExchange(RABBITMQ_DB_PERSIST_EXCHANGE, "direct", {
+        durable: true,
+    });
+}
+
+async function createSubscriberChannel(nodeId: string) {
+    subscriberConnection = await amqp.connect(RABBITMQ_URL);
+    const connection = subscriberConnection;
+
+    connection.on("error", (error) => {
+        console.error("[WS][RabbitMQ] subscriber connection error", error);
+    });
+    connection.on("close", () => {
+        subscriberConnection = null;
+        subscriberChannel = null;
+        activeConsumerTag = null;
+
+        if (subscribedNodeId && subscribedHandler) {
+            scheduleResubscribe(subscribedNodeId, subscribedHandler);
+        }
+    });
+
+    const channel = await connection.createChannel();
+    subscriberChannel = channel;
+    await assertExchange(channel);
+
+    const queueName = `${RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX}.${nodeId}`;
+
+    const queueOptions: Options.AssertQueue = {
+        durable: true,
+        arguments: {
+            // Prevent dead queues from living forever if a node is removed.
+            "x-expires": 24 * 60 * 60 * 1000,
+        },
+    };
+
+    const assertedQueue = await channel.assertQueue(queueName, queueOptions);
+
+    const partitions = normalizePositiveInt(RABBITMQ_ROOM_EVENTS_PARTITIONS, 16);
+    for (let partition = 0; partition < partitions; partition += 1) {
+        await channel.bindQueue(
+            assertedQueue.queue,
+            RABBITMQ_ROOM_EVENTS_EXCHANGE,
+            partitionRoutingKey(partition)
+        );
+    }
+
+    await channel.prefetch(normalizePositiveInt(RABBITMQ_PREFETCH, 200));
+
+    return assertedQueue.queue;
+}
+
+async function createPersistSubscriberChannel() {
+    persistSubscriberConnection = await amqp.connect(RABBITMQ_URL);
+    const connection = persistSubscriberConnection;
+
+    connection.on("error", (error) => {
+        console.error("[WS][RabbitMQ] persist subscriber connection error", error);
+    });
+
+    connection.on("close", () => {
+        persistSubscriberConnection = null;
+        persistSubscriberChannel = null;
+        activePersistConsumerTag = null;
+
+        if (persistSubscribedHandler) {
+            schedulePersistResubscribe(persistSubscribedHandler);
+        }
+    });
+
+    const channel = await connection.createChannel();
+    persistSubscriberChannel = channel;
+    await channel.assertExchange(RABBITMQ_DB_PERSIST_EXCHANGE, "direct", {
+        durable: true,
+    });
+    await channel.assertQueue(RABBITMQ_DB_PERSIST_QUEUE, {
+        durable: true,
+    });
+    await channel.bindQueue(
+        RABBITMQ_DB_PERSIST_QUEUE,
+        RABBITMQ_DB_PERSIST_EXCHANGE,
+        RABBITMQ_DB_PERSIST_ROUTING_KEY
+    );
+    await channel.prefetch(normalizePositiveInt(RABBITMQ_PREFETCH, 200));
+}
+
+async function ensurePublisherChannel() {
+    if (publisherConnection && publisherChannel) {
+        return;
+    }
+
+    await createPublisherChannel();
+}
+
+function scheduleResubscribe(nodeId: string, handler: (event: RoomSnapshotBroadcastEvent) => void | Promise<void>) {
+    if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+    }
+
+    reconnectTimer = setTimeout(() => {
+        reconnectTimer = null;
+        void subscribeDurableRoomEvents(nodeId, handler);
+    }, 1000);
+}
+
+function schedulePersistResubscribe(handler: (job: RoomPersistJob) => void | Promise<void>) {
+    if (persistReconnectTimer) {
+        clearTimeout(persistReconnectTimer);
+    }
+
+    persistReconnectTimer = setTimeout(() => {
+        persistReconnectTimer = null;
+        void subscribeRoomPersistJobs(handler);
+    }, 1000);
+}
+
+export async function publishDurableRoomEvent(event: RoomSnapshotBroadcastEvent) {
+    const validatedEvent = RoomSnapshotBroadcastEventSchema.parse(event);
+    await ensurePublisherChannel();
+
+    const routingKey = partitionRoutingKey(roomPartition(validatedEvent.roomId));
+    const content = Buffer.from(JSON.stringify(validatedEvent));
+
+    const acceptedByBuffer = publisherChannel!.publish(
+        RABBITMQ_ROOM_EVENTS_EXCHANGE,
+        routingKey,
+        content,
+        {
+            persistent: true,
+            contentType: "application/json",
+            timestamp: validatedEvent.publishedAtMs,
+            messageId: validatedEvent.actionId,
+            type: validatedEvent.type,
+        }
+    );
+
+    if (!acceptedByBuffer) {
+        await once(publisherChannel!, "drain");
+    }
+
+    await publisherChannel!.waitForConfirms();
+}
+
+async function consumeMessage(
+    message: ConsumeMessage,
+    handler: (event: RoomSnapshotBroadcastEvent) => void | Promise<void>
+) {
+    if (!subscriberChannel) {
+        return;
+    }
+
+    let payload: unknown;
+    try {
+        payload = JSON.parse(message.content.toString("utf8"));
+    } catch {
+        subscriberChannel.ack(message);
+        return;
+    }
+
+    const parsed = RoomSnapshotBroadcastEventSchema.safeParse(payload);
+    if (!parsed.success) {
+        subscriberChannel.ack(message);
+        return;
+    }
+
+    const normalizedEvent: RoomSnapshotBroadcastEvent = {
+        ...parsed.data,
+        shapes: parsed.data.shapes as Shape[],
+    };
+
+    try {
+        await handler(normalizedEvent);
+        subscriberChannel.ack(message);
+    } catch (error) {
+        console.error("[WS][RabbitMQ] failed to process durable room event", error);
+        subscriberChannel.nack(message, false, true);
+    }
+}
+
+async function consumePersistMessage(
+    message: ConsumeMessage,
+    handler: (job: RoomPersistJob) => void | Promise<void>
+) {
+    if (!persistSubscriberChannel) {
+        return;
+    }
+
+    let payload: unknown;
+    try {
+        payload = JSON.parse(message.content.toString("utf8"));
+    } catch {
+        persistSubscriberChannel.ack(message);
+        return;
+    }
+
+    const parsed = RoomPersistJobSchema.safeParse(payload);
+    if (!parsed.success) {
+        persistSubscriberChannel.ack(message);
+        return;
+    }
+
+    const job: RoomPersistJob = {
+        ...parsed.data,
+        shapes: parsed.data.shapes as Shape[],
+    };
+
+    try {
+        await handler(job);
+        persistSubscriberChannel.ack(message);
+    } catch (error) {
+        console.error("[WS][RabbitMQ] failed to process room persist job", error);
+        persistSubscriberChannel.nack(message, false, true);
+    }
+}
+
+export async function publishRoomPersistJob(job: RoomPersistJob) {
+    const validatedJob = RoomPersistJobSchema.parse(job);
+    await ensurePublisherChannel();
+
+    const acceptedByBuffer = publisherChannel!.publish(
+        RABBITMQ_DB_PERSIST_EXCHANGE,
+        RABBITMQ_DB_PERSIST_ROUTING_KEY,
+        Buffer.from(JSON.stringify(validatedJob)),
+        {
+            persistent: true,
+            contentType: "application/json",
+            timestamp: validatedJob.enqueuedAtMs,
+            messageId: validatedJob.jobId,
+            type: "room_persist_job",
+        }
+    );
+
+    if (!acceptedByBuffer) {
+        await once(publisherChannel!, "drain");
+    }
+
+    await publisherChannel!.waitForConfirms();
+}
+
+export async function subscribeRoomPersistJobs(
+    handler: (job: RoomPersistJob) => void | Promise<void>
+) {
+    persistSubscribedHandler = handler;
+
+    if (!persistSubscriberConnection || !persistSubscriberChannel) {
+        await createPersistSubscriberChannel();
+    }
+
+    if (activePersistConsumerTag) {
+        return;
+    }
+
+    const consumeResult = await persistSubscriberChannel!.consume(
+        RABBITMQ_DB_PERSIST_QUEUE,
+        (message) => {
+            if (!message) {
+                return;
+            }
+
+            void consumePersistMessage(message, handler);
+        },
+        {
+            noAck: false,
+        }
+    );
+
+    activePersistConsumerTag = consumeResult.consumerTag;
+}
+
+export async function subscribeDurableRoomEvents(
+    nodeId: string,
+    handler: (event: RoomSnapshotBroadcastEvent) => void | Promise<void>
+) {
+    subscribedNodeId = nodeId;
+    subscribedHandler = handler;
+
+    if (!subscriberConnection || !subscriberChannel) {
+        const queue = await createSubscriberChannel(nodeId);
+
+        const consumeResult = await subscriberChannel!.consume(
+            queue,
+            (message) => {
+                if (!message) {
+                    return;
+                }
+
+                void consumeMessage(message, handler);
+            },
+            {
+                noAck: false,
+            }
+        );
+
+        activeConsumerTag = consumeResult.consumerTag;
+        return;
+    }
+
+    if (activeConsumerTag) {
+        return;
+    }
+
+    const queue = `${RABBITMQ_ROOM_EVENTS_QUEUE_PREFIX}.${nodeId}`;
+    const consumeResult = await subscriberChannel.consume(
+        queue,
+        (message) => {
+            if (!message) {
+                return;
+            }
+
+            void consumeMessage(message, handler);
+        },
+        {
+            noAck: false,
+        }
+    );
+
+    activeConsumerTag = consumeResult.consumerTag;
+}
+
+export async function closeDurableRoomEventBus() {
+    if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = null;
+    }
+
+    if (persistReconnectTimer) {
+        clearTimeout(persistReconnectTimer);
+        persistReconnectTimer = null;
+    }
+
+    try {
+        if (subscriberChannel && activeConsumerTag) {
+            await subscriberChannel.cancel(activeConsumerTag);
+            activeConsumerTag = null;
+        }
+
+        if (persistSubscriberChannel && activePersistConsumerTag) {
+            await persistSubscriberChannel.cancel(activePersistConsumerTag);
+            activePersistConsumerTag = null;
+        }
+    } catch {
+        // Ignore shutdown races.
+    }
+
+    await Promise.all([
+        subscriberChannel?.close().catch(() => undefined),
+        subscriberConnection?.close().catch(() => undefined),
+        persistSubscriberChannel?.close().catch(() => undefined),
+        persistSubscriberConnection?.close().catch(() => undefined),
+        publisherChannel?.close().catch(() => undefined),
+        publisherConnection?.close().catch(() => undefined),
+    ]);
+
+    subscriberChannel = null;
+    subscriberConnection = null;
+    persistSubscriberChannel = null;
+    persistSubscriberConnection = null;
+    publisherChannel = null;
+    publisherConnection = null;
+    activePersistConsumerTag = null;
+    subscribedNodeId = null;
+    subscribedHandler = null;
+    persistSubscribedHandler = null;
+}

--- a/packages/queue-sync/tsconfig.json
+++ b/packages/queue-sync/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../typescript-config/base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  }
+}

--- a/packages/redis-sync/src/index.ts
+++ b/packages/redis-sync/src/index.ts
@@ -2,6 +2,7 @@ import {randomUUID} from "node:crypto";
 import Redis from "ioredis";
 import type {Shape} from "@repo/canvas-engine";
 import type {RoomSyncState} from "@repo/common";
+import {RoomSnapshotBroadcastEventSchema} from "@repo/common/ws-protocol";
 import {REDIS_URL} from "@repo/backend-common/config";
 
 export const NODE_ID = randomUUID();
@@ -28,6 +29,7 @@ export type RedisRoomEvent = {
     version: number;
     shapes: Shape[];
     senderId?: string;
+    actionId: string;
     publishedAtMs: number;
     type: "canvas_snapshot_broadcast";
 };
@@ -117,7 +119,7 @@ export async function commitRoomSnapshot(
     roomId: number,
     expectedVersion: number,
     snapshot: Shape[],
-    event: Pick<RedisRoomEvent, "originNodeId" | "senderId">
+    event: Pick<RedisRoomEvent, "originNodeId" | "senderId" | "actionId">
 ) {
     await ensureReady();
 
@@ -136,6 +138,7 @@ export async function commitRoomSnapshot(
             roomId,
             originNodeId: event.originNodeId,
             senderId: event.senderId,
+            actionId: event.actionId,
             publishedAtMs: Date.now(),
             type: "canvas_snapshot_broadcast",
             version: nextVersion,
@@ -170,11 +173,17 @@ export async function subscribeRoomEvents(handler: (event: RedisRoomEvent) => vo
             }
 
             const event = JSON.parse(message) as RedisRoomEvent;
-            if (typeof event.roomId !== "number" || !event.originNodeId) {
+            const parsedEvent = RoomSnapshotBroadcastEventSchema.safeParse(event);
+            if (!parsedEvent.success) {
                 return;
             }
 
-            await handler(event);
+            const normalizedEvent = {
+                ...parsedEvent.data,
+                shapes: parsedEvent.data.shapes as Shape[],
+            } as RedisRoomEvent;
+
+            await handler(normalizedEvent);
         } catch (error) {
             console.error("[WS][Redis] Failed to process room event", {channel, error});
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,9 @@ importers:
       '@repo/db':
         specifier: 'workspace: *'
         version: link:../../packages/db
+      '@repo/queue-sync':
+        specifier: 'workspace: *'
+        version: link:../../packages/queue-sync
       '@repo/redis-sync':
         specifier: 'workspace: *'
         version: link:../../packages/redis-sync
@@ -267,6 +270,34 @@ importers:
       typescript-eslint:
         specifier: ^8.50.0
         version: 8.50.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.2)
+
+  packages/queue-sync:
+    dependencies:
+      '@repo/backend-common':
+        specifier: 'workspace: *'
+        version: link:../backend-common
+      '@repo/canvas-engine':
+        specifier: 'workspace: *'
+        version: link:../canvas-engine
+      '@repo/common':
+        specifier: 'workspace: *'
+        version: link:../common
+      amqplib:
+        specifier: ^0.10.8
+        version: 0.10.9
+      zod:
+        specifier: ^4.1.11
+        version: 4.3.6
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: 'workspace: *'
+        version: link:../typescript-config
+      '@types/amqplib':
+        specifier: ^0.10.7
+        version: 0.10.8
+      '@types/node':
+        specifier: ^22.15.3
+        version: 22.15.3
 
   packages/redis-sync:
     dependencies:
@@ -905,6 +936,9 @@ packages:
   '@tailwindcss/postcss@4.2.1':
     resolution: {integrity: sha512-OEwGIBnXnj7zJeonOh6ZG9woofIjGrd2BORfvE5p9USYKDCZoQmfqLcfNiRWoJlRWLdNPn2IgVZuWAOM4iTYMw==}
 
+  '@types/amqplib@0.10.8':
+    resolution: {integrity: sha512-vtDp8Pk1wsE/AuQ8/Rgtm6KUZYqcnTgNvEHwzCkX8rL7AGsC6zqAfKAAJhUZXFhM/Pp++tbnUHiam/8vVpPztA==}
+
   '@types/bcrypt@6.0.0':
     resolution: {integrity: sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==}
 
@@ -1060,6 +1094,10 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  amqplib@0.10.9:
+    resolution: {integrity: sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==}
+    engines: {node: '>=10'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1159,6 +1197,9 @@ packages:
 
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
+
+  buffer-more-ints@1.0.0:
+    resolution: {integrity: sha512-EMetuGFz5SLsT0QTnXzINh4Ksr+oo4i+UGTXEshiGCQWnsgSs7ZhJ8fzlwQ+OzEMs0MpDAMr1hxnblp5a4vcHg==}
 
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
@@ -2392,6 +2433,9 @@ packages:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
 
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -2450,6 +2494,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2774,6 +2821,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   utrie@1.0.2:
     resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
@@ -3319,6 +3369,10 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
+  '@types/amqplib@0.10.8':
+    dependencies:
+      '@types/node': 22.15.3
+
   '@types/bcrypt@6.0.0':
     dependencies:
       '@types/node': 22.15.3
@@ -3523,6 +3577,11 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  amqplib@0.10.9:
+    dependencies:
+      buffer-more-ints: 1.0.0
+      url-parse: 1.5.10
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
@@ -3663,6 +3722,8 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-equal-constant-time@1.0.1: {}
+
+  buffer-more-ints@1.0.0: {}
 
   bytes@3.1.2: {}
 
@@ -4993,6 +5054,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  querystringify@2.2.0: {}
+
   queue-microtask@1.2.3: {}
 
   raf@3.4.1:
@@ -5057,6 +5120,8 @@ snapshots:
   remeda@2.33.4: {}
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -5455,6 +5520,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   utrie@1.0.2:
     dependencies:


### PR DESCRIPTION
- Added RabbitMQ integration for durable room event publishing and consumption.
- Introduced `publishDurableRoomEvent` and `subscribeDurableRoomEvents` functions in the queue-sync package.
- Updated message handling in the WebSocket backend to utilize durable events.
- Enhanced metrics to track durable publish failures and consumed events.
- Refactored room synchronization logic to enqueue persistence jobs via RabbitMQ.
- Updated documentation to reflect changes in architecture and scaling considerations. Closes #60