### PR TITLE
feat(chat): implement canvas chat functionality with message types an…

### DIFF
--- a/apps/ai-worker/package.json
+++ b/apps/ai-worker/package.json
@@ -5,8 +5,8 @@
   "description": "Gemini-powered AI canvas generation worker for Canvas.io",
   "main": "src/index.ts",
   "scripts": {
-    "dev": "ts-node --esm src/index.ts",
-    "start": "ts-node --esm src/index.ts"
+    "dev": "ts-node --esm --experimentalSpecifierResolution=node src/index.ts",
+    "start": "ts-node --esm --experimentalSpecifierResolution=node src/index.ts"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.0",

--- a/apps/http-backend/src/controllers/room.controller.ts
+++ b/apps/http-backend/src/controllers/room.controller.ts
@@ -12,6 +12,8 @@ import {
     RoomAccessRequestDecisionSchema,
     AiGenerateRequestSchema,
     AiGenerateJobIdParamSchema,
+    type ChatParticipant,
+    type PersistedChatMessage,
 } from "@repo/common/types";
 import {asyncHandler} from "../utils/asyncHandler";
 import {publishAiGenerateJob} from "@repo/queue-sync";
@@ -34,6 +36,49 @@ function buildCanonicalRoomPath(room: {slug: string; admin: {handle: string | nu
     // Use the owner handle when we have one. Fall back to the slug-only canvas
     // route so invite/open flows still work for accounts that have not set a handle.
     return handle ? `/room/${handle}/${room.slug}` : `/canvas/${room.slug}`;
+}
+
+type ChatRecordWithUsers = {
+    id: number;
+    roomId: number;
+    message: string;
+    messageType: "GROUP" | "DIRECT" | "COMMENT";
+    shapeId: string | null;
+    createdAt: Date;
+    user: ChatParticipant;
+    recipient: ChatParticipant | null;
+};
+
+function mapChatParticipant(user: {
+    id: string;
+    name: string;
+    handle: string | null;
+    photo?: string | null;
+}): ChatParticipant {
+    return {
+        id: user.id,
+        name: user.name,
+        handle: user.handle,
+        photo: user.photo ?? null,
+    };
+}
+
+function mapPersistedChatMessage(chat: ChatRecordWithUsers): PersistedChatMessage {
+    return {
+        id: chat.id,
+        roomId: chat.roomId,
+        kind:
+            chat.messageType === "DIRECT"
+                ? "direct"
+                : chat.messageType === "COMMENT"
+                    ? "comment"
+                    : "group",
+        body: chat.message,
+        shapeId: chat.shapeId ?? null,
+        createdAt: chat.createdAt.toISOString(),
+        sender: chat.user,
+        recipient: chat.recipient,
+    };
 }
 
 async function assertOwnerRoomAccess(roomId: number, userId: string) {
@@ -326,6 +371,204 @@ const getShapes = asyncHandler(async (req, res) => {
         }
         throw err;
     }
+});
+
+const getRoomChatBootstrap = asyncHandler(async (req, res) => {
+    const paramsValidation = RoomIdParamSchema.safeParse(req.params);
+    if (!paramsValidation.success) {
+        throw new ApiError(400, "Invalid roomId");
+    }
+
+    const {roomId} = paramsValidation.data;
+    const userId = requireUserId(req.userId);
+    const canAccess = await hasRoomAccess(roomId, userId);
+    if (!canAccess) {
+        throw new ApiError(403, "Forbidden");
+    }
+
+    const room = await prismaClient.room.findUnique({
+        where: {id: roomId},
+        select: {
+            admin: {
+                select: {
+                    id: true,
+                    name: true,
+                    handle: true,
+                    photo: true,
+                },
+            },
+            members: {
+                select: {
+                    user: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                },
+            },
+        },
+    });
+
+    if (!room) {
+        throw new ApiError(404, "Room not found");
+    }
+
+    let groupMessagesRaw: Array<any> = [];
+    let directMessagesRaw: Array<any> = [];
+    let commentsRaw: Array<any> = [];
+
+    try {
+        [groupMessagesRaw, directMessagesRaw, commentsRaw] = await Promise.all([
+            prismaClient.chat.findMany({
+                where: {
+                    roomId,
+                    messageType: "GROUP",
+                },
+                include: {
+                    user: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                    recipient: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                },
+                orderBy: {
+                    createdAt: "desc",
+                },
+                take: 80,
+            }),
+            prismaClient.chat.findMany({
+                where: {
+                    roomId,
+                    messageType: "DIRECT",
+                    OR: [
+                        {userId},
+                        {recipientId: userId},
+                    ],
+                },
+                include: {
+                    user: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                    recipient: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                },
+                orderBy: {
+                    createdAt: "desc",
+                },
+                take: 160,
+            }),
+            prismaClient.chat.findMany({
+                where: {
+                    roomId,
+                    messageType: "COMMENT",
+                },
+                include: {
+                    user: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                    recipient: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                },
+                orderBy: {
+                    createdAt: "desc",
+                },
+                take: 120,
+            }),
+        ]);
+    } catch (error: any) {
+        if (error?.code !== "P2021" && error?.code !== "P2022") {
+            throw error;
+        }
+
+        groupMessagesRaw = [];
+        directMessagesRaw = [];
+        commentsRaw = [];
+    }
+
+    const participantsMap = new Map<string, ChatParticipant>();
+    participantsMap.set(room.admin.id, mapChatParticipant(room.admin));
+    for (const member of room.members) {
+        participantsMap.set(member.user.id, mapChatParticipant(member.user));
+    }
+
+    const groupMessages = [...groupMessagesRaw]
+        .reverse()
+        .map((chat) =>
+            mapPersistedChatMessage({
+                ...chat,
+                user: mapChatParticipant(chat.user),
+                recipient: chat.recipient ? mapChatParticipant(chat.recipient) : null,
+            })
+        );
+
+    const directMessages = [...directMessagesRaw]
+        .reverse()
+        .map((chat) =>
+            mapPersistedChatMessage({
+                ...chat,
+                user: mapChatParticipant(chat.user),
+                recipient: chat.recipient ? mapChatParticipant(chat.recipient) : null,
+            })
+        );
+
+    const comments = [...commentsRaw]
+        .reverse()
+        .map((chat) =>
+            mapPersistedChatMessage({
+                ...chat,
+                user: mapChatParticipant(chat.user),
+                recipient: chat.recipient ? mapChatParticipant(chat.recipient) : null,
+            })
+        );
+
+    return res.status(200).json(
+        new ApiResponse(
+            200,
+            {
+                participants: [...participantsMap.values()],
+                groupMessages,
+                directMessages,
+                comments,
+            },
+            "Chat bootstrap fetched"
+        )
+    );
 });
 
 
@@ -967,6 +1210,7 @@ export {
     createRoom,
     listMyRooms,
     getShapes,
+    getRoomChatBootstrap,
     replaceShapes,
     getRoomIdFromSlug,
     getRoomByOwnerAndSlug,
@@ -979,4 +1223,3 @@ export {
     getAiGenerateStatus,
     receiveAiResult,
 };
-

--- a/apps/http-backend/src/routes/room.routes.ts
+++ b/apps/http-backend/src/routes/room.routes.ts
@@ -10,6 +10,7 @@ import {
 	replaceShapes,
 	renameRoomSlug,
 	getInviteLink,
+	getRoomChatBootstrap,
 	requestRoomAccess,
 	listIncomingRoomAccessRequests,
 	decideRoomAccessRequest,
@@ -21,6 +22,7 @@ const roomRouter: Router = Router()
 
 roomRouter.post("/", authenticate, idempotencyMiddleware, createRoom)
 roomRouter.get("/mine", authenticate, listMyRooms)
+roomRouter.get("/:roomId/chat/bootstrap", authenticate, getRoomChatBootstrap)
 roomRouter.get("/:roomId/shapes",authenticate, getShapes);
 roomRouter.put("/:roomId/shapes", authenticate, idempotencyMiddleware, replaceShapes);
 roomRouter.get("/room/slug/:slug", authenticate, getRoomIdFromSlug)

--- a/apps/web/app/canvas/[roomId]/page.tsx
+++ b/apps/web/app/canvas/[roomId]/page.tsx
@@ -4,16 +4,18 @@ import {ReactNode, useCallback, useEffect, useRef, useState} from "react";
 import {useParams, useSearchParams} from "next/navigation";
 import {AxiosError} from "axios";
 import {jsPDF} from "jspdf";
-import {attachEvents} from "@repo/canvas-engine";
+import {attachEvents, convertToPoints} from "@repo/canvas-engine";
 import {CanvasState} from "@repo/canvas-engine";
 import type {Shape, Tool} from "@repo/canvas-engine";
 import {HTTP_BACKEND} from "../../../config";
 import {apiClient} from "../../lib/apiClient";
 import {ensureAuthenticated, logoutUser} from "../../lib/auth";
 import {useTheme} from "../../components/ThemeToggle";
+import {useCanvasChat} from "../../../hooks/useCanvasChat";
 import {useCanvasSync} from "../../../hooks/useCanvasSync";
 import {RemotePresenceLayer} from "../../components/RemotePresenceLayer";
 import {AiChatModal, AiTriggerButton} from "../../components/AiPromptBar";
+import {CanvasMessenger} from "../../components/CanvasMessenger";
 
 const STYLE_SWATCHES = ["#1e1e1e", "#e03131", "#2f9e44", "#1971c2", "#f08c00", "#ffffff"];
 const FILL_STYLE_OPTIONS: Array<{value: NonNullable<Shape["fillStyle"]>; label: string}> = [
@@ -168,6 +170,15 @@ type Toast = {
     id: number;
     tone: "success" | "error" | "info";
     message: string;
+};
+
+type FloatingShapeComment = {
+    id: string;
+    shapeId: string;
+    body: string;
+    authorLabel: string;
+    x: number;
+    y: number;
 };
 
 type ExportFormat = "png" | "svg" | "pdf" | "json";
@@ -716,11 +727,15 @@ export default function CanvasPage() {
     const [requestDecisionInFlightId, setRequestDecisionInFlightId] = useState<number | null>(null);
     const [toasts, setToasts] = useState<Toast[]>([]);
     const [isClearCanvasModalOpen, setIsClearCanvasModalOpen] = useState(false);
+    const [styleCommentDraft, setStyleCommentDraft] = useState("");
+    const [floatingShapeComments, setFloatingShapeComments] = useState<FloatingShapeComment[]>([]);
     const menuButtonRef = useRef<HTMLButtonElement | null>(null);
     const menuPanelRef = useRef<HTMLDivElement | null>(null);
     const menuFocusIndexRef = useRef(0);
     const toastIdRef = useRef(0);
     const skipNextViewportPersistRef = useRef(false);
+    const seenRealtimeCommentIdsRef = useRef<Set<number>>(new Set());
+    const recentFloatingCommentKeysRef = useRef<Map<string, number>>(new Map());
     const {theme, toggleTheme} = useTheme();
     const isDark = theme === "dark";
 
@@ -1227,6 +1242,16 @@ export default function CanvasPage() {
         localTool: activeTool,
     });
 
+    const chat = useCanvasChat({
+        roomId: resolvedRoomId,
+        enabled: resolvedRoomId !== null,
+        currentUserId: syncResult.currentUserId,
+        presenceState: syncResult.presenceState,
+        realtimeChatMessages: syncResult.realtimeChatMessages,
+        sendWsMessage: syncResult.sendWsMessage,
+        lastSyncError: syncResult.lastSyncError,
+    });
+
     useEffect(() => {
         if (syncStatusTimerRef.current) {
             clearTimeout(syncStatusTimerRef.current);
@@ -1323,6 +1348,86 @@ export default function CanvasPage() {
 
     const primarySelectedShape = selectedShapes[selectedShapes.length - 1] ?? null;
     const isTextShapeSelection = primarySelectedShape?.type === "text";
+    const selectedShapeComments = primarySelectedShape
+        ? chat.commentsByShapeId.get(primarySelectedShape.id) ?? []
+        : [];
+
+    const spawnFloatingComment = useCallback(
+        (shapeId: string, body: string, authorLabel: string, dedupeKey: string) => {
+            if (!canvasState) return;
+
+            const now = Date.now();
+            const lastShownAt = recentFloatingCommentKeysRef.current.get(dedupeKey) ?? 0;
+            if (now - lastShownAt < 2200) {
+                return;
+            }
+            recentFloatingCommentKeysRef.current.set(dedupeKey, now);
+
+            const targetShape = canvasState.getShapes().find((shape) => shape.id === shapeId);
+            if (!targetShape) {
+                return;
+            }
+
+            const bounds = convertToPoints(targetShape);
+            const nextComment: FloatingShapeComment = {
+                id: `${now}-${Math.random().toString(16).slice(2, 8)}`,
+                shapeId,
+                body,
+                authorLabel,
+                x: (bounds.x1 + bounds.x2) / 2,
+                y: bounds.y1 - 26,
+            };
+
+            setFloatingShapeComments((current) => [...current.slice(-5), nextComment]);
+            window.setTimeout(() => {
+                setFloatingShapeComments((current) => current.filter((comment) => comment.id !== nextComment.id));
+            }, 4200);
+        },
+        [canvasState]
+    );
+
+    useEffect(() => {
+        setStyleCommentDraft("");
+    }, [primarySelectedShape?.id]);
+
+    useEffect(() => {
+        for (const message of syncResult.realtimeChatMessages) {
+            if (message.kind !== "comment" || !message.shapeId) {
+                continue;
+            }
+
+            if (seenRealtimeCommentIdsRef.current.has(message.id)) {
+                continue;
+            }
+
+            seenRealtimeCommentIdsRef.current.add(message.id);
+            spawnFloatingComment(
+                message.shapeId,
+                message.body,
+                message.sender.id === syncResult.currentUserId ? "You" : message.sender.name,
+                `realtime:${message.id}`
+            );
+        }
+    }, [spawnFloatingComment, syncResult.currentUserId, syncResult.realtimeChatMessages]);
+
+    const handleAddStyleComment = () => {
+        const nextComment = styleCommentDraft.trim();
+        if (!primarySelectedShape || !nextComment) return;
+
+        const sent = chat.sendComment(primarySelectedShape.id, nextComment);
+        if (!sent) {
+            pushToast("error", "Comment could not be sent right now.");
+            return;
+        }
+
+        spawnFloatingComment(
+            primarySelectedShape.id,
+            nextComment,
+            "You",
+            `local:${syncResult.currentUserId ?? "self"}:${primarySelectedShape.id}:${nextComment.toLowerCase()}`
+        );
+        setStyleCommentDraft("");
+    };
 
     const applyToSelectedShapes = (updates: Partial<Shape>) => {
         if (!canvasState || selectedIds.length === 0) return;
@@ -2334,6 +2439,55 @@ export default function CanvasPage() {
                         </div>
                     )}
 
+                    <div className="mb-3">
+                        <div className="mb-1 flex items-center justify-between">
+                            <label className="block text-xs font-medium opacity-80">Shape Comment</label>
+                            <span className="text-[11px] opacity-60">
+                                {selectedShapeComments.length} {selectedShapeComments.length === 1 ? "comment" : "comments"}
+                            </span>
+                        </div>
+                        <div
+                            className={`rounded-xl border p-2 ${
+                                isDark ? "border-white/10 bg-[#222222]" : "border-slate-200 bg-slate-50/80"
+                            }`}
+                        >
+                            <textarea
+                                value={styleCommentDraft}
+                                onChange={(event) => setStyleCommentDraft(event.target.value)}
+                                onKeyDown={(event) => {
+                                    if (event.key === "Enter" && !event.shiftKey) {
+                                        event.preventDefault();
+                                        handleAddStyleComment();
+                                    }
+                                }}
+                                rows={2}
+                                placeholder={
+                                    primarySelectedShape
+                                        ? `Add a comment to #${primarySelectedShape.id.slice(0, 8)}`
+                                        : "Select a shape to comment"
+                                }
+                                className={`w-full resize-none bg-transparent text-sm outline-none ${
+                                    isDark ? "text-white placeholder:text-white/35" : "text-slate-800 placeholder:text-slate-400"
+                                }`}
+                            />
+                            <div className="mt-2 flex items-center justify-between gap-2">
+                                <div className="text-[11px] opacity-60">Comments also appear in Messenger.</div>
+                                <button
+                                    type="button"
+                                    onClick={handleAddStyleComment}
+                                    disabled={!primarySelectedShape || styleCommentDraft.trim().length === 0}
+                                    className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition ${
+                                        isDark
+                                            ? "bg-white text-black hover:bg-white/90 disabled:bg-white/20 disabled:text-white/40"
+                                            : "bg-slate-900 text-white hover:bg-slate-800 disabled:bg-slate-200 disabled:text-slate-400"
+                                    }`}
+                                >
+                                    Add comment
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+
                     {!isTextShapeSelection && (
                         <div className="mb-3">
                             <label className="mb-1 block text-xs font-medium opacity-80">Drawing Persona</label>
@@ -2458,7 +2612,7 @@ export default function CanvasPage() {
                 }`}
                 style={{maxWidth: "calc(100vw - 2rem)"}}
             >
-                <div className="flex flex-nowrap items-center gap-1 overflow-x-auto scrollbar-none px-1">
+                <div className="flex flex-nowrap items-center gap-1 overflow-x-auto scrollbar-none canvas-hide-scrollbar px-1">
                     {TOOLS.map((tool, idx) => {
                         const isActive = activeTool === tool.id;
                         return (
@@ -2539,36 +2693,40 @@ export default function CanvasPage() {
                 </div>
             </div>
 
+            <CanvasMessenger
+                currentUserId={syncResult.currentUserId}
+                connectedUsersCount={connectedUsersCount}
+                presenceState={remotePresenceState}
+                selectedShapeIds={selectedIds}
+                isDark={isDark}
+                syncStatus={syncStatus}
+                chat={chat}
+            />
 
-            {/* Sync Status */}
-            <div className="absolute bottom-4 right-4 z-20">
-                <div
-                    className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium backdrop-blur ${
-                        syncStatus === "connected"
-                            ? isDark
-                                ? "bg-green-500/15 text-green-300"
-                                : "bg-green-100 text-green-700"
-                            : syncStatus === "error"
-                                ? isDark
-                                    ? "bg-red-500/15 text-red-300"
-                                    : "bg-red-100 text-red-700"
-                            : isDark
-                                ? "bg-yellow-500/15 text-yellow-300"
-                                : "bg-yellow-100 text-yellow-700"
-                    }`}
-                >
-                    <span
-                        className={`h-2 w-2 rounded-full ${
-                            syncStatus === "connected"
-                                ? "bg-green-500"
-                                : syncStatus === "error"
-                                    ? "bg-red-500"
-                                    : "bg-yellow-500"
-                        }`}
-                    />
-                    {connectedUsersCount} {connectedUsersCount === 1 ? "user connected" : "users connected"}
+            {viewport && floatingShapeComments.length > 0 && (
+                <div className="pointer-events-none absolute inset-0 z-25">
+                    {floatingShapeComments.map((comment) => (
+                        <div
+                            key={comment.id}
+                            className={`absolute -translate-x-1/2 rounded-2xl border px-3 py-2 text-xs shadow-lg ${
+                                isDark
+                                    ? "border-white/15 bg-[#141414]/95 text-white"
+                                    : "border-slate-200 bg-white/96 text-slate-800"
+                            }`}
+                            style={{
+                                left: comment.x * viewport.scale + viewport.x,
+                                top: comment.y * viewport.scale + viewport.y,
+                                maxWidth: 220,
+                            }}
+                        >
+                            <div className={`mb-1 font-semibold ${isDark ? "text-blue-200" : "text-blue-700"}`}>
+                                {comment.authorLabel} commented
+                            </div>
+                            <div className="wrap-break-word">{comment.body}</div>
+                        </div>
+                    ))}
                 </div>
-            </div>
+            )}
 
             <RemotePresenceLayer
                 presenceState={remotePresenceState}

--- a/apps/web/app/components/CanvasMessenger.tsx
+++ b/apps/web/app/components/CanvasMessenger.tsx
@@ -1,0 +1,646 @@
+"use client";
+
+import {useEffect, useMemo, useRef, useState} from "react";
+import type {RoomPresenceState} from "@repo/common";
+import {MessageCircleMore, MessagesSquare, SendHorizontal, Users, X} from "lucide-react";
+import type {CanvasChatMessage, UseCanvasChatResult} from "../../hooks/useCanvasChat";
+
+type CanvasMessengerProps = {
+    currentUserId: string | null;
+    connectedUsersCount: number;
+    presenceState: RoomPresenceState;
+    selectedShapeIds: string[];
+    isDark: boolean;
+    syncStatus: "connected" | "disconnected" | "error";
+    chat: UseCanvasChatResult;
+};
+
+type MessengerTab = "group" | "direct" | "comments";
+
+function formatTime(isoDate: string) {
+    try {
+        return new Intl.DateTimeFormat(undefined, {
+            hour: "numeric",
+            minute: "2-digit",
+        }).format(new Date(isoDate));
+    } catch {
+        return isoDate;
+    }
+}
+
+function shortShapeId(shapeId: string | null | undefined) {
+    if (!shapeId) return "shape";
+    return shapeId.length > 10 ? `${shapeId.slice(0, 8)}...` : shapeId;
+}
+
+function MessageBubble({
+    message,
+    isMine,
+    isDark,
+    showShapeId = false,
+}: {
+    message: CanvasChatMessage;
+    isMine: boolean;
+    isDark: boolean;
+    showShapeId?: boolean;
+}) {
+    return (
+        <div className={`flex ${isMine ? "justify-end" : "justify-start"}`}>
+            <div className={`max-w-[82%] ${isMine ? "items-end" : "items-start"} flex flex-col`}>
+                <div
+                    className={`mb-1 flex items-center gap-2 text-[11px] ${
+                        isDark ? "text-white/45" : "text-slate-500"
+                    }`}
+                >
+                    <span>{isMine ? "You" : message.sender.name}</span>
+                    <span>{formatTime(message.createdAt)}</span>
+                    {showShapeId && message.shapeId ? (
+                        <span
+                            className={`rounded-full px-2 py-0.5 ${
+                                isDark ? "bg-white/10 text-white/70" : "bg-slate-100 text-slate-600"
+                            }`}
+                        >
+                            #{shortShapeId(message.shapeId)}
+                        </span>
+                    ) : null}
+                </div>
+                <div
+                    className={`rounded-2xl px-3 py-2 text-sm shadow-sm ${
+                        message.deliveryState === "failed"
+                            ? isDark
+                                ? "border border-red-400/30 bg-red-500/12 text-red-100"
+                                : "border border-red-200 bg-red-50 text-red-700"
+                            : 
+                        isMine
+                            ? "bg-[#0a7cff] text-white"
+                            : isDark
+                                ? "border border-white/10 bg-[#1e1e1e] text-white/92"
+                                : "border border-slate-200 bg-white text-slate-700"
+                    }`}
+                >
+                    {message.body}
+                </div>
+                {message.deliveryState === "sending" ? (
+                    <div className={`mt-1 text-[11px] ${isDark ? "text-white/40" : "text-slate-400"}`}>Sending…</div>
+                ) : null}
+                {message.deliveryState === "failed" ? (
+                    <div className={`mt-1 text-[11px] ${isDark ? "text-red-300" : "text-red-600"}`}>
+                        {message.failureReason ?? "Failed to send"}
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function Composer({
+    value,
+    onChange,
+    onSend,
+    placeholder,
+    isDark,
+    disabled = false,
+}: {
+    value: string;
+    onChange: (value: string) => void;
+    onSend: () => void;
+    placeholder: string;
+    isDark: boolean;
+    disabled?: boolean;
+}) {
+    return (
+        <div
+            className={`flex items-end gap-2 rounded-2xl border p-2 ${
+                isDark ? "border-white/10 bg-[#161616]" : "border-slate-200 bg-white"
+            }`}
+        >
+            <textarea
+                value={value}
+                onChange={(event) => onChange(event.target.value)}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter" && !event.shiftKey) {
+                        event.preventDefault();
+                        onSend();
+                    }
+                }}
+                disabled={disabled}
+                rows={1}
+                placeholder={placeholder}
+                className={`max-h-24 min-h-10 flex-1 resize-none bg-transparent px-2 py-2 text-sm outline-none ${
+                    isDark ? "text-white placeholder:text-white/35" : "text-slate-700 placeholder:text-slate-400"
+                } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+            />
+            <button
+                type="button"
+                onClick={onSend}
+                disabled={disabled || value.trim().length === 0}
+                className="flex h-10 w-10 items-center justify-center rounded-xl bg-[#0a7cff] text-white transition hover:bg-[#0670e7] disabled:cursor-not-allowed disabled:bg-[#8ebeff]"
+                title="Send message"
+            >
+                <SendHorizontal className="h-4 w-4" />
+            </button>
+        </div>
+    );
+}
+
+export function CanvasMessenger({
+    currentUserId,
+    connectedUsersCount,
+    selectedShapeIds,
+    isDark,
+    syncStatus,
+    chat,
+}: CanvasMessengerProps) {
+    const [isOpen, setIsOpen] = useState(false);
+    const [activeTab, setActiveTab] = useState<MessengerTab>("group");
+    const [groupDraft, setGroupDraft] = useState("");
+    const [directDraft, setDirectDraft] = useState("");
+    const [commentDraft, setCommentDraft] = useState("");
+    const [selectedPartnerId, setSelectedPartnerId] = useState<string | null>(null);
+    const [commentView, setCommentView] = useState<"all" | "selected">("all");
+    const [composerError, setComposerError] = useState<string | null>(null);
+    const [unreadCount, setUnreadCount] = useState(0);
+    const [directUnreadCount, setDirectUnreadCount] = useState(0);
+    const scrollEndRef = useRef<HTMLDivElement | null>(null);
+    const knownIncomingIdsRef = useRef<Set<number>>(new Set());
+    const knownDirectIncomingIdsRef = useRef<Set<number>>(new Set());
+    const hasInitializedUnreadRef = useRef(false);
+
+    const selectedShapeId = selectedShapeIds[0] ?? null;
+    const canAttemptSend = true;
+
+    useEffect(() => {
+        if (selectedShapeId) {
+            setCommentView("selected");
+        }
+    }, [selectedShapeId]);
+
+    useEffect(() => {
+        if (chat.dmParticipants.length === 0) {
+            setSelectedPartnerId(null);
+            return;
+        }
+
+        const stillExists = chat.dmParticipants.some((participant) => participant.id === selectedPartnerId);
+        if (stillExists) {
+            return;
+        }
+
+        const nextPartner = chat.dmParticipants.find((participant) => participant.isOnline) ?? chat.dmParticipants[0];
+        setSelectedPartnerId(nextPartner?.id ?? null);
+    }, [chat.dmParticipants, selectedPartnerId]);
+
+    const selectedPartner = useMemo(
+        () => chat.dmParticipants.find((participant) => participant.id === selectedPartnerId) ?? null,
+        [chat.dmParticipants, selectedPartnerId]
+    );
+
+    const directMessagesForPartner = useMemo(() => {
+        if (!selectedPartnerId) return [];
+        return chat.getDirectMessagesForUser(selectedPartnerId);
+    }, [chat, selectedPartnerId]);
+
+    const visibleComments = useMemo(() => {
+        if (commentView === "selected" && selectedShapeId) {
+            return chat.commentsByShapeId.get(selectedShapeId) ?? [];
+        }
+
+        return chat.comments;
+    }, [chat.comments, chat.commentsByShapeId, commentView, selectedShapeId]);
+
+    useEffect(() => {
+        scrollEndRef.current?.scrollIntoView({behavior: "smooth"});
+    }, [activeTab, chat.comments.length, chat.directMessages.length, chat.groupMessages.length, selectedPartnerId, commentView]);
+
+    useEffect(() => {
+        const incomingMessages = [...chat.groupMessages, ...chat.comments].filter(
+            (message) => message.id > 0 && !message.optimistic
+        );
+
+        if (!hasInitializedUnreadRef.current) {
+            hasInitializedUnreadRef.current = true;
+            knownIncomingIdsRef.current = new Set(incomingMessages.map((message) => message.id));
+            return;
+        }
+
+        const nextIds = new Set(knownIncomingIdsRef.current);
+        let nextUnread = 0;
+
+        for (const message of incomingMessages) {
+            if (nextIds.has(message.id)) {
+                continue;
+            }
+
+            nextIds.add(message.id);
+            if (message.sender.id !== currentUserId && !isOpen) {
+                nextUnread += 1;
+            }
+        }
+
+        knownIncomingIdsRef.current = nextIds;
+        if (nextUnread > 0) {
+            setUnreadCount((current) => current + nextUnread);
+        }
+    }, [chat.comments, chat.directMessages, chat.groupMessages, currentUserId, isOpen]);
+
+    useEffect(() => {
+        const incomingDirectMessages = chat.directMessages.filter(
+            (message) => message.id > 0 && !message.optimistic && message.sender.id !== currentUserId
+        );
+
+        if (!hasInitializedUnreadRef.current) {
+            knownDirectIncomingIdsRef.current = new Set(incomingDirectMessages.map((message) => message.id));
+            return;
+        }
+
+        const nextIds = new Set(knownDirectIncomingIdsRef.current);
+        let nextUnread = 0;
+        const isViewingDirectThread = isOpen && activeTab === "direct" && selectedPartnerId !== null;
+
+        for (const message of incomingDirectMessages) {
+            if (nextIds.has(message.id)) {
+                continue;
+            }
+
+            nextIds.add(message.id);
+
+            const threadPartnerId = message.sender.id === currentUserId ? message.recipient?.id ?? null : message.sender.id;
+            const isVisibleThread = isViewingDirectThread && threadPartnerId === selectedPartnerId;
+
+            if (!isVisibleThread) {
+                nextUnread += 1;
+            }
+        }
+
+        knownDirectIncomingIdsRef.current = nextIds;
+        if (nextUnread > 0) {
+            setDirectUnreadCount((current) => current + nextUnread);
+        }
+    }, [activeTab, chat.directMessages, currentUserId, isOpen, selectedPartnerId]);
+
+    useEffect(() => {
+        if (isOpen && activeTab === "direct" && selectedPartnerId) {
+            setDirectUnreadCount(0);
+        }
+    }, [activeTab, isOpen, selectedPartnerId]);
+
+    const syncToneClass =
+        syncStatus === "connected"
+            ? "bg-green-500"
+            : syncStatus === "error"
+                ? "bg-red-500"
+                : "bg-yellow-500";
+
+    const panelSurface = isDark ? "border-white/10 bg-[#101114]/95 text-white" : "border-slate-200 bg-white/95 text-slate-800";
+    const mutedText = isDark ? "text-white/55" : "text-slate-500";
+    const scrollAreaClass = "canvas-hide-scrollbar";
+    const totalUnreadCount = unreadCount + directUnreadCount;
+
+    const sendGroupMessage = () => {
+        const next = groupDraft.trim();
+        if (!next) return;
+
+        const sent = chat.sendGroupMessage(next);
+        if (!sent) {
+            setComposerError("Chat is waiting for the canvas connection.");
+            return;
+        }
+
+        setComposerError(null);
+        setGroupDraft("");
+    };
+
+    const sendDirectMessage = () => {
+        const next = directDraft.trim();
+        if (!next || !selectedPartnerId) return;
+
+        const sent = chat.sendDirectMessage(selectedPartnerId, next);
+        if (!sent) {
+            setComposerError("Direct message could not be sent right now.");
+            return;
+        }
+
+        setComposerError(null);
+        setDirectDraft("");
+    };
+
+    const sendComment = () => {
+        const next = commentDraft.trim();
+        if (!next || !selectedShapeId) return;
+
+        const sent = chat.sendComment(selectedShapeId, next);
+        if (!sent) {
+            setComposerError("Comment could not be attached right now.");
+            return;
+        }
+
+        setComposerError(null);
+        setCommentDraft("");
+        setCommentView("selected");
+    };
+
+    return (
+        <>
+            {isOpen ? (
+                <div
+                    className={`absolute bottom-20 right-4 z-30 flex h-[min(72dvh,38rem)] w-[min(92vw,25rem)] flex-col overflow-hidden rounded-[26px] border shadow-[0_28px_60px_rgba(15,23,42,0.28)] ${panelSurface}`}
+                    style={{
+                        backdropFilter: "blur(14px)",
+                        WebkitBackdropFilter: "blur(14px)",
+                        isolation: "isolate",
+                        contain: "layout paint",
+                    }}
+                >
+                    <div className="flex items-center justify-between bg-linear-to-r from-[#0a7cff] via-[#1783ff] to-[#22a2ff] px-4 py-3 text-white">
+                        <div>
+                            <div className="text-sm font-semibold">Canvas Messenger</div>
+                            <div className="text-xs text-white/80">
+                                {connectedUsersCount} {connectedUsersCount === 1 ? "person here" : "people here"}
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={() => setIsOpen(false)}
+                            className="flex h-8 w-8 items-center justify-center rounded-full bg-white/15 transition hover:bg-white/25"
+                            aria-label="Close chat"
+                        >
+                            <X className="h-4 w-4" />
+                        </button>
+                    </div>
+
+                    <div className={`flex gap-2 border-b px-3 py-3 ${isDark ? "border-white/10" : "border-slate-200"}`}>
+                        {[
+                            {id: "group" as const, label: "Canvas", icon: Users},
+                            {id: "direct" as const, label: "Direct", icon: MessageCircleMore},
+                            {id: "comments" as const, label: "Comments", icon: MessagesSquare},
+                        ].map((tab) => {
+                            const Icon = tab.icon;
+                            const isActive = activeTab === tab.id;
+
+                            return (
+                                <button
+                                    key={tab.id}
+                                    type="button"
+                                    onClick={() => setActiveTab(tab.id)}
+                                    className={`relative flex flex-1 items-center justify-center gap-2 rounded-full px-3 py-2 text-sm font-medium transition ${
+                                        isActive
+                                            ? "bg-[#0a7cff] text-white"
+                                            : isDark
+                                                ? "bg-white/5 text-white/75 hover:bg-white/10"
+                                                : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                                    }`}
+                                >
+                                    <Icon className="h-4 w-4" />
+                                    {tab.label}
+                                    {tab.id === "direct" && directUnreadCount > 0 ? (
+                                        <span className="absolute -right-1 -top-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white shadow-lg">
+                                            {directUnreadCount > 9 ? "9+" : directUnreadCount}
+                                        </span>
+                                    ) : null}
+                                </button>
+                            );
+                        })}
+                    </div>
+
+                    {composerError ? (
+                        <div className={`px-4 pt-3 text-xs ${isDark ? "text-red-300" : "text-red-600"}`}>{composerError}</div>
+                    ) : null}
+
+                    {chat.error ? (
+                        <div className={`px-4 pt-3 text-xs ${isDark ? "text-red-300" : "text-red-600"}`}>{chat.error}</div>
+                    ) : null}
+
+                    {activeTab === "direct" && chat.participants.length > 0 ? (
+                        <div className={`border-b px-4 py-2 text-xs ${isDark ? "border-white/10 text-white/60" : "border-slate-200 text-slate-500"}`}>
+                            {chat.participants.length} {chat.participants.length === 1 ? "participant available" : "participants available"}
+                        </div>
+                    ) : null}
+
+                    <div className="min-h-0 flex-1">
+                        {activeTab === "group" ? (
+                            <div className="flex h-full flex-col">
+                                <div className={`px-4 pt-3 text-xs ${mutedText}`}>
+                                    Canvas-wide chat for everyone in this room.
+                                </div>
+                                <div className={`min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4 ${scrollAreaClass}`}>
+                                    {chat.isLoading ? <div className={mutedText}>Loading messages...</div> : null}
+                                    {!chat.isLoading && chat.groupMessages.length === 0 ? (
+                                        <div className={mutedText}>Start the room conversation.</div>
+                                    ) : null}
+                                    {chat.groupMessages.map((message) => (
+                                        <MessageBubble
+                                            key={message.id}
+                                            message={message}
+                                            isMine={message.sender.id === currentUserId}
+                                            isDark={isDark}
+                                        />
+                                    ))}
+                                    <div ref={scrollEndRef} />
+                                </div>
+                                <div className="p-3">
+                                    <Composer
+                                        value={groupDraft}
+                                        onChange={setGroupDraft}
+                                        onSend={sendGroupMessage}
+                                        placeholder="Message everyone on the canvas"
+                                        isDark={isDark}
+                                        disabled={!canAttemptSend}
+                                    />
+                                </div>
+                            </div>
+                        ) : null}
+
+                        {activeTab === "direct" ? (
+                            <div className="flex h-full min-h-0 overflow-hidden">
+                                <div className={`w-32 shrink-0 border-r p-2 ${isDark ? "border-white/10" : "border-slate-200"}`}>
+                                    <div className={`mb-2 px-2 text-[11px] uppercase tracking-[0.18em] ${mutedText}`}>People</div>
+                                    <div className={`space-y-1 overflow-y-auto ${scrollAreaClass}`}>
+                                        {chat.dmParticipants.length === 0 ? (
+                                            <div className={`px-2 text-xs ${mutedText}`}>
+                                                {connectedUsersCount > 1
+                                                    ? "People are connected, but participant details are still loading."
+                                                    : "No collaborators yet."}
+                                            </div>
+                                        ) : null}
+                                        {chat.dmParticipants.map((participant) => {
+                                            const isActive = participant.id === selectedPartnerId;
+                                            const latestMessage = chat
+                                                .getDirectMessagesForUser(participant.id)
+                                                .slice(-1)[0];
+
+                                            return (
+                                                <button
+                                                    key={participant.id}
+                                                    type="button"
+                                                    onClick={() => setSelectedPartnerId(participant.id)}
+                                                    className={`w-full rounded-2xl px-2 py-2 text-left transition ${
+                                                        isActive
+                                                            ? "bg-[#0a7cff] text-white"
+                                                            : isDark
+                                                                ? "hover:bg-white/5"
+                                                                : "hover:bg-slate-100"
+                                                    }`}
+                                                >
+                                                    <div className="flex items-center gap-2">
+                                                        <span
+                                                            className={`inline-flex h-2.5 w-2.5 rounded-full ${
+                                                                participant.isOnline
+                                                                    ? "bg-green-400"
+                                                                    : isActive
+                                                                        ? "bg-white/60"
+                                                                        : "bg-slate-300"
+                                                            }`}
+                                                        />
+                                                        <span className="truncate text-sm font-medium">{participant.name}</span>
+                                                    </div>
+                                                    <div className={`mt-1 truncate text-[11px] ${isActive ? "text-white/75" : mutedText}`}>
+                                                        {latestMessage?.body ?? (participant.isOnline ? "Online now" : "No messages yet")}
+                                                    </div>
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+
+                                <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+                                    <div className={`border-b px-4 py-3 ${isDark ? "border-white/10" : "border-slate-200"}`}>
+                                        <div className="text-sm font-semibold">{selectedPartner?.name ?? "Select someone"}</div>
+                                        <div className={`text-xs ${mutedText}`}>
+                                            {selectedPartner ? (selectedPartner.isOnline ? "Active on this canvas" : "Room member") : "Choose a teammate to DM"}
+                                        </div>
+                                    </div>
+                                    <div className={`min-h-0 min-w-0 flex-1 space-y-3 overflow-y-auto px-4 py-4 ${scrollAreaClass}`}>
+                                        {!selectedPartner ? <div className={mutedText}>Pick a participant to start chatting.</div> : null}
+                                        {selectedPartner && directMessagesForPartner.length === 0 ? (
+                                            <div className={mutedText}>Your personal thread with {selectedPartner.name} will appear here.</div>
+                                        ) : null}
+                                        {directMessagesForPartner.map((message) => (
+                                            <MessageBubble
+                                                key={message.id}
+                                                message={message}
+                                                isMine={message.sender.id === currentUserId}
+                                                isDark={isDark}
+                                            />
+                                        ))}
+                                        <div ref={scrollEndRef} />
+                                    </div>
+                                    <div className="p-3">
+                                        <Composer
+                                            value={directDraft}
+                                            onChange={setDirectDraft}
+                                            onSend={sendDirectMessage}
+                                            placeholder={selectedPartner ? `Message ${selectedPartner.name}` : "Select a collaborator first"}
+                                            isDark={isDark}
+                                        disabled={!selectedPartner || !canAttemptSend}
+                                    />
+                                </div>
+                            </div>
+                            </div>
+                        ) : null}
+
+                        {activeTab === "comments" ? (
+                            <div className="flex h-full flex-col">
+                                <div className={`border-b px-4 py-3 ${isDark ? "border-white/10" : "border-slate-200"}`}>
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <button
+                                            type="button"
+                                            onClick={() => setCommentView("all")}
+                                            className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+                                                commentView === "all"
+                                                    ? "bg-[#0a7cff] text-white"
+                                                    : isDark
+                                                        ? "bg-white/5 text-white/75"
+                                                        : "bg-slate-100 text-slate-600"
+                                            }`}
+                                        >
+                                            All comments
+                                        </button>
+                                        <button
+                                            type="button"
+                                            onClick={() => selectedShapeId && setCommentView("selected")}
+                                            disabled={!selectedShapeId}
+                                            className={`rounded-full px-3 py-1 text-xs font-medium transition ${
+                                                commentView === "selected" && selectedShapeId
+                                                    ? "bg-[#0a7cff] text-white"
+                                                    : isDark
+                                                        ? "bg-white/5 text-white/75"
+                                                        : "bg-slate-100 text-slate-600"
+                                            } disabled:cursor-not-allowed disabled:opacity-45`}
+                                        >
+                                            {selectedShapeId ? `Selected #${shortShapeId(selectedShapeId)}` : "Select a shape to comment"}
+                                        </button>
+                                    </div>
+                                    <div className={`mt-2 text-xs ${mutedText}`}>
+                                        Comments stay attached to shapes and reload with the room history.
+                                    </div>
+                                </div>
+                                <div className={`min-h-0 flex-1 space-y-3 overflow-y-auto px-4 py-4 ${scrollAreaClass}`}>
+                                    {visibleComments.length === 0 ? (
+                                        <div className={mutedText}>
+                                            {commentView === "selected" && selectedShapeId
+                                                ? "No comments on this shape yet."
+                                                : "Shape comments will appear here."}
+                                        </div>
+                                    ) : null}
+                                    {visibleComments.map((message) => (
+                                        <MessageBubble
+                                            key={message.id}
+                                            message={message}
+                                            isMine={message.sender.id === currentUserId}
+                                            isDark={isDark}
+                                            showShapeId={commentView === "all"}
+                                        />
+                                    ))}
+                                    <div ref={scrollEndRef} />
+                                </div>
+                                <div className="p-3">
+                                    <Composer
+                                        value={commentDraft}
+                                        onChange={setCommentDraft}
+                                        onSend={sendComment}
+                                        placeholder={
+                                            selectedShapeId
+                                                ? `Comment on #${shortShapeId(selectedShapeId)}`
+                                                : "Select a shape to leave a comment"
+                                        }
+                                        isDark={isDark}
+                                        disabled={!selectedShapeId || !canAttemptSend}
+                                    />
+                                </div>
+                            </div>
+                        ) : null}
+                    </div>
+                </div>
+            ) : null}
+
+            <div className="absolute bottom-20 right-4 z-20">
+                <div className="relative">
+                    <button
+                        type="button"
+                        onClick={() => setIsOpen((current) => !current)}
+                        className="flex h-12 w-12 items-center justify-center rounded-full bg-linear-to-br from-[#0a7cff] via-[#1783ff] to-[#29a8ff] text-white shadow-[0_18px_38px_rgba(10,124,255,0.38)] transition hover:scale-[1.03]"
+                        aria-label={isOpen ? "Close canvas messenger" : "Open canvas messenger"}
+                    >
+                        <MessageCircleMore className="h-5 w-5" />
+                    </button>
+                    {totalUnreadCount > 0 ? (
+                        <span className="absolute -right-1 -top-1 inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold text-white shadow-lg">
+                            {totalUnreadCount > 9 ? "9+" : totalUnreadCount}
+                        </span>
+                    ) : null}
+                </div>
+            </div>
+
+            <div className="absolute bottom-4 right-4 z-20">
+                <div
+                    className={`flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium backdrop-blur ${
+                        isDark ? "bg-[#151515]/88 text-white/88" : "bg-white/88 text-slate-700"
+                    }`}
+                >
+                    <span className={`h-2.5 w-2.5 rounded-full ${syncToneClass}`} />
+                    {connectedUsersCount} {connectedUsersCount === 1 ? "user connected" : "users connected"}
+                </div>
+            </div>
+        </>
+    );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -107,6 +107,21 @@ body {
   overflow-x: hidden;
 }
 
+/* Hide scrollbars while keeping the element scrollable. Useful for Safari's overlay scrollbar UI. */
+.scrollbar-none,
+.canvas-hide-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.scrollbar-none::-webkit-scrollbar,
+.canvas-hide-scrollbar::-webkit-scrollbar {
+  display: none;
+  width: 0;
+  height: 0;
+}
+
 body {
   color: var(--foreground);
   background: var(--background);

--- a/apps/web/hooks/useCanvasChat.ts
+++ b/apps/web/hooks/useCanvasChat.ts
@@ -1,0 +1,504 @@
+"use client";
+
+import {useCallback, useEffect, useMemo, useRef, useState} from "react";
+import type {
+    ClientMessage,
+    ChatParticipant,
+    PersistedChatMessage,
+    RoomChatBootstrap,
+    RoomPresenceState,
+} from "@repo/common";
+import {RoomChatBootstrapSchema} from "@repo/common";
+import {HTTP_BACKEND} from "../config";
+import {apiClient} from "../app/lib/apiClient";
+
+type SendWsMessage = (message: ClientMessage) => boolean;
+type DeliveryState = "sending" | "failed";
+
+export type CanvasChatMessage = PersistedChatMessage & {
+    deliveryState?: DeliveryState;
+    failureReason?: string | null;
+    optimistic?: boolean;
+};
+
+export type UseCanvasChatResult = {
+    isLoading: boolean;
+    error: string | null;
+    participants: ChatParticipant[];
+    dmParticipants: Array<ChatParticipant & {isOnline: boolean}>;
+    groupMessages: CanvasChatMessage[];
+    directMessages: CanvasChatMessage[];
+    comments: CanvasChatMessage[];
+    commentsByShapeId: Map<string, CanvasChatMessage[]>;
+    getDirectMessagesForUser: (partnerUserId: string) => CanvasChatMessage[];
+    sendGroupMessage: (body: string) => boolean;
+    sendDirectMessage: (recipientUserId: string, body: string) => boolean;
+    sendComment: (shapeId: string, body: string) => boolean;
+};
+
+type UseCanvasChatOptions = {
+    roomId: number | null;
+    enabled?: boolean;
+    currentUserId: string | null;
+    presenceState: RoomPresenceState;
+    realtimeChatMessages: PersistedChatMessage[];
+    sendWsMessage: SendWsMessage;
+    lastSyncError?: string | null;
+};
+
+function mergeById<T extends PersistedChatMessage>(existing: T[], incoming: T[]) {
+    const merged = new Map<number, T>();
+
+    for (const message of existing) {
+        merged.set(message.id, message);
+    }
+
+    for (const message of incoming) {
+        merged.set(message.id, message);
+    }
+
+    return [...merged.values()].sort((a, b) => {
+        if (a.createdAt === b.createdAt) {
+            return a.id - b.id;
+        }
+
+        return a.createdAt.localeCompare(b.createdAt);
+    });
+}
+
+function isChatRelatedError(message: string | null | undefined) {
+    if (!message) return false;
+
+    const lower = message.toLowerCase();
+    return (
+        lower.includes("chat") ||
+        lower.includes("comment") ||
+        lower.includes("recipient") ||
+        lower.includes("shape not found")
+    );
+}
+
+function isMessageResolved(optimisticMessage: CanvasChatMessage, persistedMessages: PersistedChatMessage[]) {
+    const optimisticTimestamp = Date.parse(optimisticMessage.createdAt);
+
+    return persistedMessages.some((persistedMessage) => {
+        if (persistedMessage.kind !== optimisticMessage.kind) return false;
+        if (persistedMessage.body !== optimisticMessage.body) return false;
+        if (persistedMessage.sender.id !== optimisticMessage.sender.id) return false;
+        if ((persistedMessage.recipient?.id ?? null) !== (optimisticMessage.recipient?.id ?? null)) return false;
+        if ((persistedMessage.shapeId ?? null) !== (optimisticMessage.shapeId ?? null)) return false;
+
+        const persistedTimestamp = Date.parse(persistedMessage.createdAt);
+        if (!Number.isFinite(optimisticTimestamp) || !Number.isFinite(persistedTimestamp)) {
+            return true;
+        }
+
+        return Math.abs(persistedTimestamp - optimisticTimestamp) <= 2 * 60 * 1000;
+    });
+}
+
+export function useCanvasChat({
+    roomId,
+    enabled = true,
+    currentUserId,
+    presenceState,
+    realtimeChatMessages,
+    sendWsMessage,
+    lastSyncError = null,
+}: UseCanvasChatOptions): UseCanvasChatResult {
+    const [participants, setParticipants] = useState<RoomChatBootstrap["participants"]>([]);
+    const [groupMessages, setGroupMessages] = useState<PersistedChatMessage[]>([]);
+    const [directMessages, setDirectMessages] = useState<PersistedChatMessage[]>([]);
+    const [comments, setComments] = useState<PersistedChatMessage[]>([]);
+    const [optimisticMessages, setOptimisticMessages] = useState<CanvasChatMessage[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const realtimeMessagesRef = useRef(realtimeChatMessages);
+    const optimisticIdRef = useRef(-1);
+
+    useEffect(() => {
+        realtimeMessagesRef.current = realtimeChatMessages;
+    }, [realtimeChatMessages]);
+
+    useEffect(() => {
+        if (!enabled || roomId === null) {
+            setParticipants([]);
+            setGroupMessages([]);
+            setDirectMessages([]);
+            setComments([]);
+            setOptimisticMessages([]);
+            setError(null);
+            setIsLoading(false);
+            return;
+        }
+
+        let isCancelled = false;
+        setIsLoading(true);
+        setError(null);
+
+        void apiClient
+            .get(`${HTTP_BACKEND}/room/${roomId}/chat/bootstrap`)
+            .then((response) => {
+                if (isCancelled) return;
+
+                const parsed = RoomChatBootstrapSchema.safeParse(response.data?.data);
+                if (!parsed.success) {
+                    setError("Unable to read chat history.");
+                    setParticipants([]);
+                    setGroupMessages([]);
+                    setDirectMessages([]);
+                    setComments([]);
+                    return;
+                }
+
+                setParticipants(parsed.data.participants);
+                setGroupMessages(
+                    mergeById(
+                        parsed.data.groupMessages,
+                        realtimeMessagesRef.current.filter((message) => message.kind === "group")
+                    )
+                );
+                setDirectMessages(
+                    mergeById(
+                        parsed.data.directMessages,
+                        realtimeMessagesRef.current.filter((message) => message.kind === "direct")
+                    )
+                );
+                setComments(
+                    mergeById(
+                        parsed.data.comments,
+                        realtimeMessagesRef.current.filter((message) => message.kind === "comment")
+                    )
+                );
+            })
+            .catch(() => {
+                if (isCancelled) return;
+                setError("Unable to load chat history.");
+                setParticipants([]);
+                setGroupMessages([]);
+                setDirectMessages([]);
+                setComments([]);
+            })
+            .finally(() => {
+                if (!isCancelled) {
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [enabled, roomId]);
+
+    useEffect(() => {
+        if (realtimeChatMessages.length === 0) {
+            return;
+        }
+
+        const incomingGroup = realtimeChatMessages.filter((message) => message.kind === "group");
+        const incomingDirect = realtimeChatMessages.filter((message) => message.kind === "direct");
+        const incomingComments = realtimeChatMessages.filter((message) => message.kind === "comment");
+
+        if (incomingGroup.length > 0) {
+            setGroupMessages((existing) => mergeById(existing, incomingGroup));
+        }
+
+        if (incomingDirect.length > 0) {
+            setDirectMessages((existing) => mergeById(existing, incomingDirect));
+        }
+
+        if (incomingComments.length > 0) {
+            setComments((existing) => mergeById(existing, incomingComments));
+        }
+    }, [realtimeChatMessages]);
+
+    useEffect(() => {
+        const persistedMessages = [...groupMessages, ...directMessages, ...comments];
+        setOptimisticMessages((existing) =>
+            existing.filter((message) => {
+                if (message.deliveryState === "failed") {
+                    return true;
+                }
+
+                return !isMessageResolved(message, persistedMessages);
+            })
+        );
+    }, [comments, directMessages, groupMessages]);
+
+    useEffect(() => {
+        if (!isChatRelatedError(lastSyncError)) {
+            return;
+        }
+
+        setOptimisticMessages((existing) =>
+            existing.map((message) =>
+                message.deliveryState === "sending"
+                    ? {
+                        ...message,
+                        deliveryState: "failed",
+                        failureReason: lastSyncError,
+                    }
+                    : message
+            )
+        );
+        setError(lastSyncError);
+    }, [lastSyncError]);
+
+    const onlineUserIds = useMemo(
+        () => new Set((presenceState.presences ?? []).map((presence) => presence.userId)),
+        [presenceState.presences]
+    );
+
+    const mergedParticipants = useMemo(() => {
+        const next = new Map<string, ChatParticipant>();
+
+        for (const participant of participants) {
+            next.set(participant.id, participant);
+        }
+
+        for (const presence of presenceState.presences ?? []) {
+            if (!next.has(presence.userId)) {
+                next.set(presence.userId, {
+                    id: presence.userId,
+                    name: presence.userName,
+                    handle: null,
+                    photo: null,
+                });
+            }
+        }
+
+        if (currentUserId && !next.has(currentUserId)) {
+            const selfPresence = (presenceState.presences ?? []).find((presence) => presence.userId === currentUserId);
+            if (selfPresence) {
+                next.set(currentUserId, {
+                    id: selfPresence.userId,
+                    name: selfPresence.userName,
+                    handle: null,
+                    photo: null,
+                });
+            }
+        }
+
+        return [...next.values()];
+    }, [currentUserId, participants, presenceState.presences]);
+
+    const dmParticipants = useMemo(() => {
+        return mergedParticipants
+            .filter((participant) => participant.id !== currentUserId)
+            .map((participant) => ({
+                ...participant,
+                isOnline: onlineUserIds.has(participant.id),
+            }))
+            .sort((left, right) => {
+                if (left.isOnline !== right.isOnline) {
+                    return left.isOnline ? -1 : 1;
+                }
+
+                return left.name.localeCompare(right.name);
+            });
+    }, [currentUserId, mergedParticipants, onlineUserIds]);
+
+    const commentsByShapeId = useMemo(() => {
+        const next = new Map<string, CanvasChatMessage[]>();
+
+        for (const comment of [
+            ...comments,
+            ...optimisticMessages.filter((message) => message.kind === "comment"),
+        ]) {
+            if (!comment.shapeId) continue;
+
+            const existing = next.get(comment.shapeId) ?? [];
+            existing.push(comment);
+            next.set(comment.shapeId, existing);
+        }
+
+        return next;
+    }, [comments, optimisticMessages]);
+
+    const getDirectMessagesForUser = useCallback(
+        (partnerUserId: string) =>
+            [...directMessages, ...optimisticMessages.filter((message) => message.kind === "direct")].filter((message) => {
+                const senderId = message.sender.id;
+                const recipientId = message.recipient?.id ?? null;
+
+                return (
+                    (senderId === currentUserId && recipientId === partnerUserId) ||
+                    (senderId === partnerUserId && recipientId === currentUserId)
+                );
+            }),
+        [currentUserId, directMessages, optimisticMessages]
+    );
+
+    const createOptimisticMessage = useCallback(
+        (kind: PersistedChatMessage["kind"], body: string, options?: {recipient?: ChatParticipant | null; shapeId?: string | null}) => {
+            const selfParticipant =
+                mergedParticipants.find((participant) => participant.id === currentUserId) ??
+                ((presenceState.presences ?? []).find((presence) => presence.userId === currentUserId)
+                    ? {
+                        id: currentUserId!,
+                        name: (presenceState.presences ?? []).find((presence) => presence.userId === currentUserId)!.userName,
+                        handle: null,
+                        photo: null,
+                    }
+                    : null);
+
+            if (!selfParticipant || roomId === null) {
+                return null;
+            }
+
+            const nextMessage: CanvasChatMessage = {
+                id: optimisticIdRef.current,
+                roomId,
+                kind,
+                body,
+                shapeId: options?.shapeId ?? null,
+                createdAt: new Date().toISOString(),
+                sender: selfParticipant,
+                recipient: options?.recipient ?? null,
+                optimistic: true,
+                deliveryState: "sending",
+                failureReason: null,
+            };
+
+            optimisticIdRef.current -= 1;
+            setOptimisticMessages((existing) => [...existing, nextMessage]);
+            return nextMessage;
+        },
+        [currentUserId, mergedParticipants, presenceState.presences, roomId]
+    );
+
+    const sendGroupMessage = useCallback(
+        (body: string) => {
+            if (roomId === null) return false;
+
+            const optimisticMessage = createOptimisticMessage("group", body);
+            if (!optimisticMessage) {
+                return false;
+            }
+
+            const sent = sendWsMessage({
+                type: "send_chat_message",
+                roomId,
+                kind: "group",
+                body,
+            });
+            if (!sent) {
+                setOptimisticMessages((existing) =>
+                    existing.map((message) =>
+                        message.id === optimisticMessage.id
+                            ? {
+                                ...message,
+                                deliveryState: "failed",
+                                failureReason: "Chat is waiting for the canvas connection.",
+                            }
+                            : message
+                    )
+                );
+            }
+
+            return sent;
+        },
+        [createOptimisticMessage, roomId, sendWsMessage]
+    );
+
+    const sendDirectMessage = useCallback(
+        (recipientUserId: string, body: string) => {
+            if (roomId === null) return false;
+
+            const recipient = mergedParticipants.find((participant) => participant.id === recipientUserId) ?? null;
+            const optimisticMessage = createOptimisticMessage("direct", body, {recipient});
+            if (!optimisticMessage) {
+                return false;
+            }
+
+            const sent = sendWsMessage({
+                type: "send_chat_message",
+                roomId,
+                kind: "direct",
+                body,
+                recipientUserId,
+            });
+            if (!sent) {
+                setOptimisticMessages((existing) =>
+                    existing.map((message) =>
+                        message.id === optimisticMessage.id
+                            ? {
+                                ...message,
+                                deliveryState: "failed",
+                                failureReason: "Direct message could not be sent right now.",
+                            }
+                            : message
+                    )
+                );
+            }
+
+            return sent;
+        },
+        [createOptimisticMessage, mergedParticipants, roomId, sendWsMessage]
+    );
+
+    const sendComment = useCallback(
+        (shapeId: string, body: string) => {
+            if (roomId === null) return false;
+
+            const optimisticMessage = createOptimisticMessage("comment", body, {shapeId});
+            if (!optimisticMessage) {
+                return false;
+            }
+
+            const sent = sendWsMessage({
+                type: "send_chat_message",
+                roomId,
+                kind: "comment",
+                body,
+                shapeId,
+            });
+            if (!sent) {
+                setOptimisticMessages((existing) =>
+                    existing.map((message) =>
+                        message.id === optimisticMessage.id
+                            ? {
+                                ...message,
+                                deliveryState: "failed",
+                                failureReason: "Comment could not be attached right now.",
+                            }
+                            : message
+                    )
+                );
+            }
+
+            return sent;
+        },
+        [createOptimisticMessage, roomId, sendWsMessage]
+    );
+
+    const displayedGroupMessages = useMemo(
+        () => mergeById(groupMessages, optimisticMessages.filter((message) => message.kind === "group")),
+        [groupMessages, optimisticMessages]
+    );
+
+    const displayedDirectMessages = useMemo(
+        () => mergeById(directMessages, optimisticMessages.filter((message) => message.kind === "direct")),
+        [directMessages, optimisticMessages]
+    );
+
+    const displayedComments = useMemo(
+        () => mergeById(comments, optimisticMessages.filter((message) => message.kind === "comment")),
+        [comments, optimisticMessages]
+    );
+
+    return {
+        isLoading,
+        error,
+        participants: mergedParticipants,
+        dmParticipants,
+        groupMessages: displayedGroupMessages,
+        directMessages: displayedDirectMessages,
+        comments: displayedComments,
+        commentsByShapeId,
+        getDirectMessagesForUser,
+        sendGroupMessage,
+        sendDirectMessage,
+        sendComment,
+    };
+}

--- a/apps/web/hooks/useCanvasSync.ts
+++ b/apps/web/hooks/useCanvasSync.ts
@@ -24,6 +24,8 @@ import type {
   ServerMessage,
   RoomSyncState,
   RoomPresenceState,
+  PersistedChatMessage,
+  ClientMessage,
 } from "@repo/common";
 import type { Tool } from "@repo/canvas-engine";
 import { HTTP_BACKEND } from "../config";
@@ -92,6 +94,7 @@ export function useCanvasSync({
   const [websocketLatencyMs, setWebsocketLatencyMs] = useState<number | null>(null);
   const [inFlightSnapshotCount, setInFlightSnapshotCount] = useState(0);
   const [eventTimeline, setEventTimeline] = useState<SyncTimelineEntry[]>([]);
+  const [realtimeChatMessages, setRealtimeChatMessages] = useState<PersistedChatMessage[]>([]);
 
   const wsRef = useRef<WebSocket | null>(null);
   const isConnectedRef = useRef(false);
@@ -145,6 +148,30 @@ export function useCanvasSync({
       detail,
     };
     setEventTimeline((previous) => [...previous.slice(-59), nextEvent]);
+  }, []);
+
+  const appendRealtimeChatMessage = useCallback((message: PersistedChatMessage) => {
+    setRealtimeChatMessages((previous) => {
+      if (previous.some((existing) => existing.id === message.id)) {
+        return previous;
+      }
+
+      return [...previous, message].slice(-240);
+    });
+  }, []);
+
+  const sendWsMessage = useCallback((message: ClientMessage) => {
+    if (
+      !wsRef.current ||
+      wsRef.current.readyState !== WebSocket.OPEN ||
+      !isConnectedRef.current ||
+      !hasJoinedRoomRef.current
+    ) {
+      return false;
+    }
+
+    wsRef.current.send(JSON.stringify(message));
+    return true;
   }, []);
 
   const syncInFlightCounter = useCallback(() => {
@@ -412,6 +439,8 @@ export function useCanvasSync({
   useEffect(() => {
     if (!enabled || !state) return;
 
+    setRealtimeChatMessages([]);
+
     const ws = new WebSocket(WS_BACKEND_URL);
 
     ws.onopen = () => {
@@ -531,6 +560,8 @@ export function useCanvasSync({
             connectedUsersCount: message.connectedUsersCount,
             presences: message.presences,
           });
+        } else if (message.type === "chat_message_created") {
+          appendRealtimeChatMessage(message.message);
         } else if (message.type === "sync_error") {
           if (WS_SYNC_DEBUG) console.warn("[WS] Sync error:", message.reason);
           appendTimelineEvent("sync_error", message.reason);
@@ -680,6 +711,7 @@ export function useCanvasSync({
     syncInFlightCounter,
     cancelScheduledRemoteHydrate,
     scheduleRemoteHydrate,
+    appendRealtimeChatMessage,
   ]);
 
   return {
@@ -692,6 +724,8 @@ export function useCanvasSync({
     websocketLatencyMs,
     inFlightSnapshotCount,
     eventTimeline,
+    realtimeChatMessages,
+    sendWsMessage,
     /**
      * Live shapes ref — always current, updated synchronously before any
      * React re-render.  Pass this to RemotePresenceLayer so selection boxes

--- a/apps/ws-backend/src/ws/connectionState.ts
+++ b/apps/ws-backend/src/ws/connectionState.ts
@@ -148,6 +148,27 @@ export function broadcastToRoomAll(roomId: number, message: ServerMessage) {
 }
 
 /**
+ * Broadcasts a message to a subset of users currently connected to the room.
+ */
+export function broadcastToRoomUsers(roomId: number, message: ServerMessage, userIds: string[]) {
+    const roomSockets = activeRooms.get(roomId);
+    if (!roomSockets) return;
+
+    const allowedUserIds = new Set(userIds);
+    const serializedMessage = JSON.stringify(message);
+
+    for (const socket of roomSockets) {
+        if (!socket.userId || !allowedUserIds.has(socket.userId)) {
+            continue;
+        }
+
+        if (socket.readyState === WebSocket.OPEN) {
+            socket.send(serializedMessage);
+        }
+    }
+}
+
+/**
  * Stores the latest cursor and selection snapshot for one room participant.
  */
 export function setRoomPresence(roomId: number, userId: string, presence: RoomPresence) {

--- a/apps/ws-backend/src/ws/messageHandler.ts
+++ b/apps/ws-backend/src/ws/messageHandler.ts
@@ -2,18 +2,20 @@ import {randomUUID} from "node:crypto";
 import {RawData} from "ws";
 import type {Shape} from "@repo/canvas-engine";
 import {ClientWsMessageSchema} from "@repo/common/ws-protocol";
-import type {ServerMessage} from "@repo/common";
+import type {PersistedChatMessage, ServerMessage} from "@repo/common";
 import {prismaClient} from "@repo/db/client";
 import type {AuthenticatedWebSocket} from "./types.js";
 import {publishDurableRoomEvent} from "@repo/queue-sync";
 import {
     broadcastRoomPresenceState,
     broadcastToRoom,
+    broadcastToRoomAll,
+    broadcastToRoomUsers,
     getRoomPresenceState,
     joinActiveRoom,
     setRoomPresence,
 } from "./connectionState.js";
-import {cacheRoomSyncState, enqueueRoomPersist, initializeRoomSync} from "./roomSync.js";
+import {cacheRoomSyncState, enqueueRoomPersist, initializeRoomSync, roomSyncState} from "./roomSync.js";
 import {commitRoomSnapshot, NODE_ID} from "@repo/redis-sync";
 import {
     recordInvalidJsonPayload,
@@ -22,7 +24,6 @@ import {
     recordRateLimitedSnapshot,
     recordSnapshotCommitFailure,
     recordSnapshotCommitted,
-    recordVersionMismatch,
     recordDurablePublishFailure,
 } from "./metrics.js";
 
@@ -98,6 +99,57 @@ function rejectForbidden(ws: AuthenticatedWebSocket) {
     );
 
     ws.close(1008, "Forbidden");
+}
+
+function mapChatParticipant(user: {
+    id: string;
+    name: string;
+    handle: string | null;
+    photo?: string | null;
+}) {
+    return {
+        id: user.id,
+        name: user.name,
+        handle: user.handle,
+        photo: user.photo ?? null,
+    };
+}
+
+function mapPersistedChatMessage(chat: {
+    id: number;
+    roomId: number;
+    message: string;
+    messageType: "GROUP" | "DIRECT" | "COMMENT";
+    shapeId: string | null;
+    createdAt: Date;
+    user: {
+        id: string;
+        name: string;
+        handle: string | null;
+        photo?: string | null;
+    };
+    recipient: {
+        id: string;
+        name: string;
+        handle: string | null;
+        photo?: string | null;
+    } | null;
+}): PersistedChatMessage {
+    return {
+        id: chat.id,
+        roomId: chat.roomId,
+        kind:
+            chat.messageType === "DIRECT"
+                ? "direct"
+                : chat.messageType === "COMMENT"
+                    ? "comment"
+                    : "group",
+        body: chat.message,
+        shapeId: chat.shapeId ?? null,
+        createdAt: chat.createdAt.toISOString(),
+        sender: mapChatParticipant(chat.user),
+        recipient: chat.recipient ? mapChatParticipant(chat.recipient) : null,
+    };
 }
 
 export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: string, data: RawData) {
@@ -192,7 +244,7 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
     }
 
     if (parsed.type === "update_presence") {
-        const {roomId, cursor, selectedIds} = parsed;
+        const {roomId, selectedIds} = parsed;
 
         if (typeof roomId !== "number" || roomId <= 0) {
             ws.send(
@@ -395,5 +447,146 @@ export async function handleSocketMessage(ws: AuthenticatedWebSocket, userId: st
                 error,
             });
         });
+        return;
+    }
+
+    if (parsed.type === "send_chat_message") {
+        const {roomId, kind, body} = parsed;
+
+        if (typeof roomId !== "number" || roomId <= 0) {
+            ws.send(
+                JSON.stringify({
+                    type: "sync_error",
+                    reason: "Invalid roomId",
+                } as ServerMessage)
+            );
+            return;
+        }
+
+        if (ws.currentRoomId !== roomId) {
+            ws.send(
+                JSON.stringify({
+                    type: "sync_error",
+                    reason: "Forbidden",
+                } as ServerMessage)
+            );
+            return;
+        }
+
+        if (!ws.userId) {
+            return;
+        }
+
+        let recipientId: string | null = null;
+        let shapeId: string | null = null;
+
+        if (kind === "direct") {
+            recipientId = typeof parsed.recipientUserId === "string" ? parsed.recipientUserId : null;
+
+            if (!recipientId || recipientId === ws.userId) {
+                ws.send(
+                    JSON.stringify({
+                        type: "sync_error",
+                        reason: "Invalid direct message recipient",
+                    } as ServerMessage)
+                );
+                return;
+            }
+
+            const recipientHasAccess = await hasRoomAccess(roomId, recipientId);
+            if (!recipientHasAccess) {
+                ws.send(
+                    JSON.stringify({
+                        type: "sync_error",
+                        reason: "Recipient is not allowed in this canvas",
+                    } as ServerMessage)
+                );
+                return;
+            }
+        }
+
+        if (kind === "comment") {
+            shapeId = typeof parsed.shapeId === "string" ? parsed.shapeId : null;
+
+            if (!shapeId) {
+                ws.send(
+                    JSON.stringify({
+                        type: "sync_error",
+                        reason: "Comments must target a shape",
+                    } as ServerMessage)
+                );
+                return;
+            }
+
+            const currentRoomState = roomSyncState.get(roomId) ?? (await initializeRoomSync(roomId));
+            const shape = currentRoomState.shapes.find((candidate) => candidate.id === shapeId);
+
+            if (!shape) {
+                ws.send(
+                    JSON.stringify({
+                        type: "sync_error",
+                        reason: "Shape not found for comment",
+                    } as ServerMessage)
+                );
+                return;
+            }
+        }
+
+        let createdChat;
+        try {
+            createdChat = await prismaClient.chat.create({
+                data: {
+                    roomId,
+                    message: body,
+                    messageType: kind === "direct" ? "DIRECT" : kind === "comment" ? "COMMENT" : "GROUP",
+                    userId: ws.userId,
+                    recipientId,
+                    shapeId,
+                },
+                include: {
+                    user: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                    recipient: {
+                        select: {
+                            id: true,
+                            name: true,
+                            handle: true,
+                            photo: true,
+                        },
+                    },
+                },
+            });
+        } catch (error: any) {
+            if (error?.code === "P2021" || error?.code === "P2022") {
+                ws.send(
+                    JSON.stringify({
+                        type: "sync_error",
+                        reason: "Chat storage is not ready yet. Apply the latest database schema update.",
+                    } as ServerMessage)
+                );
+                return;
+            }
+
+            throw error;
+        }
+
+        const chatMessage: ServerMessage = {
+            type: "chat_message_created",
+            message: mapPersistedChatMessage(createdChat),
+        };
+
+        if (kind === "direct" && recipientId) {
+            broadcastToRoomUsers(roomId, chatMessage, [ws.userId, recipientId]);
+            return;
+        }
+
+        broadcastToRoomAll(roomId, chatMessage);
+        return;
     }
 }

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -2,6 +2,7 @@
   "name": "@repo/common",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,2 +1,2 @@
-export * from "./types";
-export * from "./ws-protocol";
+export * from "./types.js";
+export * from "./ws-protocol.js";

--- a/packages/common/src/types.js
+++ b/packages/common/src/types.js
@@ -1,0 +1,1 @@
+export * from "./types.ts";

--- a/packages/common/src/types.ts
+++ b/packages/common/src/types.ts
@@ -81,3 +81,38 @@ export const AiGenerateRequestSchema = z.object({
 export const AiGenerateJobIdParamSchema = z.object({
     jobId: z.string().min(8).max(128),
 });
+
+export const ChatParticipantSchema = z.object({
+    id: z.string().min(1).max(200),
+    name: z.string().min(1).max(200),
+    handle: z.string().min(1).max(200).nullable(),
+    photo: z.string().min(1).max(2048).nullable().optional(),
+});
+
+export type ChatParticipant = z.infer<typeof ChatParticipantSchema>;
+
+export const ChatMessageKindSchema = z.enum(["group", "direct", "comment"]);
+
+export type ChatMessageKind = z.infer<typeof ChatMessageKindSchema>;
+
+export const PersistedChatMessageSchema = z.object({
+    id: z.number().int().positive(),
+    roomId: z.number().int().positive(),
+    kind: ChatMessageKindSchema,
+    body: z.string().min(1).max(4000),
+    shapeId: z.string().min(1).max(200).nullable(),
+    createdAt: z.string().min(1).max(64),
+    sender: ChatParticipantSchema,
+    recipient: ChatParticipantSchema.nullable(),
+});
+
+export type PersistedChatMessage = z.infer<typeof PersistedChatMessageSchema>;
+
+export const RoomChatBootstrapSchema = z.object({
+    participants: z.array(ChatParticipantSchema),
+    groupMessages: z.array(PersistedChatMessageSchema),
+    directMessages: z.array(PersistedChatMessageSchema),
+    comments: z.array(PersistedChatMessageSchema),
+});
+
+export type RoomChatBootstrap = z.infer<typeof RoomChatBootstrapSchema>;

--- a/packages/common/src/ws-protocol.js
+++ b/packages/common/src/ws-protocol.js
@@ -1,0 +1,1 @@
+export * from "./ws-protocol.ts";

--- a/packages/common/src/ws-protocol.ts
+++ b/packages/common/src/ws-protocol.ts
@@ -15,6 +15,26 @@ const CanvasShapeSchema = z
   })
   .passthrough();
 
+const ChatParticipantSchema = z.object({
+  id: z.string().min(1).max(200),
+  name: z.string().min(1).max(200),
+  handle: z.string().min(1).max(200).nullable(),
+  photo: z.string().min(1).max(2048).nullable().optional(),
+});
+
+const ChatMessageKindSchema = z.enum(["group", "direct", "comment"]);
+
+const PersistedChatMessageSchema = z.object({
+  id: z.number().int().positive(),
+  roomId: z.number().int().positive(),
+  kind: ChatMessageKindSchema,
+  body: z.string().min(1).max(4000),
+  shapeId: z.string().min(1).max(200).nullable(),
+  createdAt: z.string().min(1).max(64),
+  sender: ChatParticipantSchema,
+  recipient: ChatParticipantSchema.nullable(),
+});
+
 const ActionIdSchema = z.string().min(8).max(128);
 
 /**
@@ -89,6 +109,37 @@ export type WsMessage =
       selectedIds: string[];
       tool: string | null;
     }
+  | {
+      type: "send_chat_message";
+      roomId: number;
+      kind: "group" | "direct" | "comment";
+      body: string;
+      recipientUserId?: string;
+      shapeId?: string;
+    }
+  | {
+      type: "chat_message_created";
+      message: {
+        id: number;
+        roomId: number;
+        kind: "group" | "direct" | "comment";
+        body: string;
+        shapeId: string | null;
+        createdAt: string;
+        sender: {
+          id: string;
+          name: string;
+          handle: string | null;
+          photo?: string | null;
+        };
+        recipient: {
+          id: string;
+          name: string;
+          handle: string | null;
+          photo?: string | null;
+        } | null;
+      };
+    }
   | RoomPresenceMessage
   | { type: "sync_error"; reason: string }
   | { type: "pong" };
@@ -117,6 +168,29 @@ export type ServerMessage =
       roomId: number;
       version: number;
     }
+  | {
+      type: "chat_message_created";
+      message: {
+        id: number;
+        roomId: number;
+        kind: "group" | "direct" | "comment";
+        body: string;
+        shapeId: string | null;
+        createdAt: string;
+        sender: {
+          id: string;
+          name: string;
+          handle: string | null;
+          photo?: string | null;
+        };
+        recipient: {
+          id: string;
+          name: string;
+          handle: string | null;
+          photo?: string | null;
+        } | null;
+      };
+    }
   | RoomPresenceMessage
   | { type: "sync_error"; reason: string }
   | { type: "pong" };
@@ -124,7 +198,7 @@ export type ServerMessage =
 // Client -> Server commands
 export type ClientMessage = Extract<
   WsMessage,
-  { type: "join_room" | "canvas_snapshot" | "update_presence" }
+  { type: "join_room" | "canvas_snapshot" | "update_presence" | "send_chat_message" }
 >;
 
 export const PresenceCursorSchema = z.object({
@@ -152,13 +226,46 @@ export const UpdatePresenceMessageSchema = z.object({
   tool: z.string().min(1).max(64).nullable(),
 });
 
+export const SendChatMessageSchema = z
+  .object({
+    type: z.literal("send_chat_message"),
+    roomId: z.number().int().positive(),
+    kind: ChatMessageKindSchema,
+    body: z.string().trim().min(1).max(2000),
+    recipientUserId: z.string().min(1).max(200).optional(),
+    shapeId: z.string().min(1).max(200).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.kind === "direct" && !value.recipientUserId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["recipientUserId"],
+        message: "recipientUserId is required for direct messages",
+      });
+    }
+
+    if (value.kind === "comment" && !value.shapeId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["shapeId"],
+        message: "shapeId is required for comments",
+      });
+    }
+  });
+
 export const ClientWsMessageSchema = z.discriminatedUnion("type", [
   JoinRoomMessageSchema,
   CanvasSnapshotMessageSchema,
   UpdatePresenceMessageSchema,
+  SendChatMessageSchema,
 ]);
 
 export type ClientWsMessage = z.infer<typeof ClientWsMessageSchema>;
+
+export const ChatMessageCreatedSchema = z.object({
+  type: z.literal("chat_message_created"),
+  message: PersistedChatMessageSchema,
+});
 
 /**
  * Per-room sync state tracked by server.

--- a/packages/db/prisma/migrations/20260424093000_add_canvas_chat_support/migration.sql
+++ b/packages/db/prisma/migrations/20260424093000_add_canvas_chat_support/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "ChatMessageType" AS ENUM ('GROUP', 'DIRECT', 'COMMENT');
+
+-- AlterTable
+ALTER TABLE "Chat"
+ADD COLUMN "messageType" "ChatMessageType" NOT NULL DEFAULT 'GROUP',
+ADD COLUMN "recipientId" TEXT,
+ADD COLUMN "shapeId" TEXT,
+ADD COLUMN "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- CreateIndex
+CREATE INDEX "Chat_roomId_messageType_createdAt_idx" ON "Chat"("roomId", "messageType", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Chat_roomId_shapeId_createdAt_idx" ON "Chat"("roomId", "shapeId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Chat_roomId_recipientId_createdAt_idx" ON "Chat"("roomId", "recipientId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "Chat" ADD CONSTRAINT "Chat_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -26,7 +26,8 @@ model User {
   rooms           Room[]
   roomMembers     RoomMember[]
   roomAccessRequests RoomAccessRequest[]
-  chats           Chat[]
+  sentChats       Chat[]  @relation("ChatSender")
+  receivedChats   Chat[]  @relation("ChatRecipient")
 }
 
 model Room {
@@ -41,6 +42,12 @@ model Room {
   accessRequests RoomAccessRequest[]
 
   @@unique([adminId, slug])
+}
+
+enum ChatMessageType {
+  GROUP
+  DIRECT
+  COMMENT
 }
 
 model RoomMember {
@@ -70,12 +77,22 @@ model RoomAccessRequest {
 }
 
 model Chat {
-  id      Int    @id @default(autoincrement())
-  roomId  Int
-  message String
-  userId  String
-  room    Room   @relation(fields: [roomId], references: [id])
-  user    User   @relation(fields: [userId], references: [id])
+  id          Int             @id @default(autoincrement())
+  roomId      Int
+  message     String
+  messageType ChatMessageType @default(GROUP)
+  userId      String
+  recipientId String?
+  shapeId     String?
+  createdAt   DateTime        @default(now())
+  updatedAt   DateTime        @updatedAt
+  room        Room            @relation(fields: [roomId], references: [id])
+  user        User            @relation("ChatSender", fields: [userId], references: [id])
+  recipient   User?           @relation("ChatRecipient", fields: [recipientId], references: [id])
+
+  @@index([roomId, messageType, createdAt])
+  @@index([roomId, shapeId, createdAt])
+  @@index([roomId, recipientId, createdAt])
 }
 
 model Shape {


### PR DESCRIPTION
…d real-time updates

- Add chat message types (GROUP, DIRECT, COMMENT) to the database schema.
- Create a new hook `useCanvasChat` for managing chat state and interactions.
- Implement WebSocket message handling for sending and receiving chat messages.
- Update connection state management to support broadcasting messages to specific users.
- Enhance the existing `useCanvasSync` hook to handle real-time chat messages.
- Add CSS styles to hide scrollbars for chat components.
- Introduce schemas for chat participants and messages using Zod for validation.
- Create necessary database migrations for chat support.
- Closes #66 